### PR TITLE
Enable space props for Card

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -11,7 +11,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ### Added
 
-- Add the `space` props to `<Card>` ([#10](https://github.com/lightspeed/flame/pull/10))
+- Enable `space` props for `<Card>` ([#10](https://github.com/lightspeed/flame/pull/10))
 
 ## 0.1.1 - 2019-09-18
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Added
+
+- Add the `space` props to `<Card>` ([#10](https://github.com/lightspeed/flame/pull/10))
+
 ## 0.1.1 - 2019-09-18
 
 ### Fixed

--- a/packages/flame/src/Card/Card.tsx
+++ b/packages/flame/src/Card/Card.tsx
@@ -186,7 +186,8 @@ export type CardProps = BackgroundColorProps &
     large: boolean;
     /** Disables default padding */
     noSpacing: boolean;
-  }>;
+  }> &
+  SpaceProps;
 
 export const Card = styled('div')<CardProps>`
   border-radius: ${themeGet('radii.radius-2')};
@@ -204,6 +205,9 @@ export const Card = styled('div')<CardProps>`
   }
 
   ${setCardVariant};
-  ${color};
+  ${compose(
+    color,
+    space,
+  )};
   ${setCardSizingProp};
 `;

--- a/packages/flame/src/Card/story.tsx
+++ b/packages/flame/src/Card/story.tsx
@@ -11,7 +11,6 @@ import { Divider } from '../Divider/index';
 import { Button } from '../Button';
 import Readme from './README.md';
 
-const leftSpace = spacing['cr-mr-2'];
 const contentSpace = spacing['cr-mb-2'];
 
 const stories = storiesOf('Card', module)
@@ -26,13 +25,13 @@ const cardsContent =
 
 stories.add('Types', () => (
   <div style={{ display: 'flex' }}>
-    <div className={cn('text-center', leftSpace)}>
-      <Card>
+    <div className={cn('text-center')}>
+      <Card mr={2}>
         <CardSection>Default Card</CardSection>
       </Card>
     </div>
-    <div className={cn('text-center', leftSpace)}>
-      <Card top>
+    <div className={cn('text-center')}>
+      <Card top mr={2}>
         <CardSection>Top Card</CardSection>
       </Card>
     </div>
@@ -43,17 +42,17 @@ stories.add('Spacing', () => (
   <div>
     <h3>Card spacing</h3>
     <div className={contentSpace} style={{ display: 'flex' }}>
-      <div className={cn('text-center', leftSpace)}>
-        <Card>
+      <div className={cn('text-center')}>
+        <Card mr={2}>
           <CardSection>Default</CardSection>
         </Card>
       </div>
-      <div className={cn('text-center', leftSpace)}>
-        <Card>
-          <CardSection large>Large</CardSection>
+      <div className={cn('text-center')}>
+        <Card mr={2} large>
+          <CardSection>Large</CardSection>
         </Card>
       </div>
-      <div className={cn('text-center', leftSpace)}>
+      <div className={cn('text-center')}>
         <Card>
           <CardSection noSpacing>No spacing</CardSection>
         </Card>


### PR DESCRIPTION
## Description

Adds the `space` props from `styled-system` to `<Card>`

Closes #8 

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006/?path=/story/card--spacing)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [ ] I have added tests that prove my fix is effective or that my feature works
