### PR TITLE
Add <Alert /> `icon` prop

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Breaking
+
+- Alert: Remove exposed `AlertState` type ([#15](https://github.com/lightspeed/flame/pull/15))
+
+### Added
+
+- Alert: Added the ability to pass `icon` ([#15](https://github.com/lightspeed/flame/pull/15))
+
 ## 0.2.0 - 2019-10-01
 
 ### Changed

--- a/packages/flame/src/Alert/Alert.test.tsx
+++ b/packages/flame/src/Alert/Alert.test.tsx
@@ -24,6 +24,13 @@ describe('Alert', () => {
     expect(component.toJSON()).toMatchSnapshot();
   });
 
+  it('renders with an icon', () => {
+    const { getByTestId } = customRender(
+      <Alert icon={<i data-testid="icon" />}>Hello World</Alert>,
+    );
+    expect(getByTestId('icon')).toBeInTheDocument();
+  });
+
   it('renders with a title', () => {
     const component = createComponent(<Alert title="My Title">Hello World</Alert>);
     expect(component.toJSON()).toMatchSnapshot();

--- a/packages/flame/src/Alert/Alert.tsx
+++ b/packages/flame/src/Alert/Alert.tsx
@@ -59,76 +59,61 @@ export interface AlertProps {
   /** Text for the alert's title */
   title?: string;
 }
-export interface AlertState {
-  closed: boolean;
-}
-class Alert extends React.Component<AlertProps & SpaceProps, AlertState> {
-  constructor(props: any) {
-    super(props);
 
-    this.state = {
-      closed: false,
-    };
+const Alert: React.FunctionComponent<AlertProps & SpaceProps> = ({
+  children,
+  type = 'info',
+  title,
+  noCloseBtn,
+  onClose,
+  ...restProps
+}) => {
+  const [isHidden, setIsHidden] = React.useState(false);
 
-    this.handleClose = this.handleClose.bind(this);
-  }
+  const handleClose = (e: React.MouseEvent<HTMLElement>) => {
+    if (onClose && typeof onClose === 'function') onClose(e);
+    setIsHidden(s => !s);
+  };
 
-  handleClose(e: React.MouseEvent<HTMLElement>) {
-    this.setState(prevState => {
-      if (this.props.onClose && typeof this.props.onClose === 'function') this.props.onClose(e);
+  if (isHidden) return null;
 
-      return {
-        closed: !prevState.closed,
-      };
-    });
-  }
-
-  render() {
-    if (this.state.closed) return null;
-    const { children, type, title, noCloseBtn, ...restProps } = this.props;
-
-    return (
-      <AlertWrapper type={type} {...restProps}>
-        <Box flex="1">
-          {title && (
-            <Text color="textHeading" fontWeight="bold" fontSize="text" mt={0} mr={0} mb={1} ml={0}>
-              {title}
-            </Text>
-          )}
-          <Box fontSize="text-s">{children}</Box>
-        </Box>
-        {!noCloseBtn && (
-          <CloseButton type="button" onClick={this.handleClose}>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 8 8"
-              css={{
-                width: '0.5em',
-                height: '0.5em',
-                fill: 'black',
-                position: 'absolute',
-                top: '0.25em',
-                left: '0.25em',
-                right: '0',
-                bottom: '0',
-              }}
-            >
-              <g fillRule="evenodd" transform="translate(-4 -4)">
-                <path
-                  fillOpacity=".5"
-                  d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
-                />
-              </g>
-            </svg>
-          </CloseButton>
+  return (
+    <AlertWrapper type={type} {...restProps}>
+      <Box flex="1">
+        {title && (
+          <Text color="textHeading" fontWeight="bold" fontSize="text" mt={0} mr={0} mb={1} ml={0}>
+            {title}
+          </Text>
         )}
-      </AlertWrapper>
-    );
-  }
-}
-
-(Alert as any).defaultProps = {
-  type: 'info',
+        <Box fontSize="text-s">{children}</Box>
+      </Box>
+      {!noCloseBtn && (
+        <CloseButton type="button" onClick={handleClose}>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 8 8"
+            css={{
+              width: '0.5em',
+              height: '0.5em',
+              fill: 'black',
+              position: 'absolute',
+              top: '0.25em',
+              left: '0.25em',
+              right: '0',
+              bottom: '0',
+            }}
+          >
+            <g fillRule="evenodd" transform="translate(-4 -4)">
+              <path
+                fillOpacity=".5"
+                d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
+              />
+            </g>
+          </svg>
+        </CloseButton>
+      )}
+    </AlertWrapper>
+  );
 };
 
 export { Alert };

--- a/packages/flame/src/Alert/Alert.tsx
+++ b/packages/flame/src/Alert/Alert.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { transparentize } from 'polished';
 import { space, variant, SpaceProps } from 'styled-system';
 import { themeGet } from '@styled-system/theme-get';
-import { Box } from '../Core';
+import { Flex, Box } from '../Core';
 import { Text } from '../Text';
 
 const alertStyles = variant({
@@ -56,6 +56,8 @@ export interface AlertProps {
   onClose?: Function;
   /** Whether a Close button appears */
   noCloseBtn?: boolean;
+  /** Icon for the alert */
+  icon?: React.ReactNode;
   /** Text for the alert's title */
   title?: string;
 }
@@ -66,6 +68,7 @@ const Alert: React.FunctionComponent<AlertProps & SpaceProps> = ({
   title,
   noCloseBtn,
   onClose,
+  icon = null,
   ...restProps
 }) => {
   const [isHidden, setIsHidden] = React.useState(false);
@@ -79,14 +82,17 @@ const Alert: React.FunctionComponent<AlertProps & SpaceProps> = ({
 
   return (
     <AlertWrapper type={type} {...restProps}>
-      <Box flex="1">
-        {title && (
-          <Text color="textHeading" fontWeight="bold" fontSize="text" mt={0} mr={0} mb={1} ml={0}>
-            {title}
-          </Text>
-        )}
-        <Box fontSize="text-s">{children}</Box>
-      </Box>
+      <Flex flex="1">
+        {icon && <Box pr={2}>{icon}</Box>}
+        <Box flex="1">
+          {title && (
+            <Text color="textHeading" fontWeight="bold" fontSize="text" mt={0} mr={0} mb={1} ml={0}>
+              {title}
+            </Text>
+          )}
+          <Box fontSize="text-s">{children}</Box>
+        </Box>
+      </Flex>
       {!noCloseBtn && (
         <CloseButton type="button" onClick={handleClose}>
           <svg

--- a/packages/flame/src/Alert/Alert.tsx
+++ b/packages/flame/src/Alert/Alert.tsx
@@ -82,8 +82,12 @@ const Alert: React.FunctionComponent<AlertProps & SpaceProps> = ({
 
   return (
     <AlertWrapper type={type} {...restProps}>
-      <Flex flex="1">
-        {icon && <Box pr={2}>{icon}</Box>}
+      <Flex flex="1" alignItems="flex-start">
+        {icon && (
+          <Flex alignItems="center" pr={2} pt="2px">
+            {icon}
+          </Flex>
+        )}
         <Box flex="1">
           {title && (
             <Text color="textHeading" fontWeight="bold" fontSize="text" mt={0} mr={0} mb={1} ml={0}>

--- a/packages/flame/src/Alert/README.md
+++ b/packages/flame/src/Alert/README.md
@@ -11,6 +11,7 @@ First, make sure you have been through the [Getting started](https://github.com/
 | Prop                  | Type                                      | Description                                |
 | --------------------- | ----------------------------------------- | ------------------------------------------ |
 | `type`                | `info`, `warning`, `danger`, or `success` | default is `info`                          |
+| `icon`                | `React.ReactNode`                         | An icon to place inside of the alert       |
 | `title`               | `string`                                  |                                            |
 | `onClose`             | `fn()`                                    | custom `fn(event)` passed the event object |
 | `noCloseBtn`          | `boolean`                                 |                                            |

--- a/packages/flame/src/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/packages/flame/src/Alert/__snapshots__/Alert.test.tsx.snap
@@ -26,6 +26,10 @@ exports[`Alert Removes close button 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -109,6 +113,10 @@ exports[`Alert renders a number 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -221,6 +229,10 @@ exports[`Alert renders correctly 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -312,6 +324,10 @@ exports[`Alert renders type danger correctly 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -445,6 +461,10 @@ exports[`Alert renders type info correctly 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -536,6 +556,10 @@ exports[`Alert renders type success correctly 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -648,6 +672,10 @@ exports[`Alert renders type warning correctly 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -781,6 +809,10 @@ exports[`Alert renders with a title 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/packages/flame/src/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/packages/flame/src/Alert/__snapshots__/Alert.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Alert Removes close button 1`] = `
-.emotion-6 {
+.emotion-8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20,6 +20,16 @@ exports[`Alert Removes close button 1`] = `
   padding: 0.75rem 1.125rem;
   background: #e9fafe;
   border-color: #2875c6;
+}
+
+.emotion-6 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .emotion-4 {
@@ -45,619 +55,35 @@ exports[`Alert Removes close button 1`] = `
 }
 
 <div
-  className="emotion-6 emotion-7"
+  className="emotion-8 emotion-9"
   type="info"
 >
   <div
-    className="emotion-4 emotion-3"
+    className="emotion-6 emotion-7"
   >
-    <p
-      className="emotion-0 emotion-1"
-      color="textHeading"
-      fontSize="text"
-      fontWeight="bold"
-    >
-      My Title
-    </p>
     <div
-      className="emotion-2 emotion-3"
-      fontSize="text-s"
+      className="emotion-4 emotion-3"
     >
-      Hello World
+      <p
+        className="emotion-0 emotion-1"
+        color="textHeading"
+        fontSize="text"
+        fontWeight="bold"
+      >
+        My Title
+      </p>
+      <div
+        className="emotion-2 emotion-3"
+        fontSize="text-s"
+      >
+        Hello World
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`Alert renders a number 1`] = `
-.emotion-7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
-  border-top: 4px solid;
-  border-radius: 0.375rem;
-  padding: 0.75rem 1.125rem;
-  background: #e9fafe;
-  border-color: #2875c6;
-}
-
-.emotion-2 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-0 {
-  font-size: 0.875rem;
-}
-
-.emotion-5 {
-  font-size: 1rem;
-  color: #0c0d0d;
-  background-color: rgba(12,13,13,0.1);
-  border-radius: 50%;
-  border: none;
-  cursor: pointer;
-  width: 1em;
-  height: 1em;
-  padding: 0;
-  position: relative;
-}
-
-.emotion-5:focus {
-  outline: none;
-}
-
-.emotion-4 {
-  width: 0.5em;
-  height: 0.5em;
-  fill: black;
-  position: absolute;
-  top: 0.25em;
-  left: 0.25em;
-  right: 0;
-  bottom: 0;
-}
-
-<div
-  className="emotion-7 emotion-8"
-  type="info"
->
-  <div
-    className="emotion-2 emotion-1"
-  >
-    <div
-      className="emotion-0 emotion-1"
-      fontSize="text-s"
-    >
-      300
-    </div>
-  </div>
-  <button
-    className="emotion-5 emotion-6"
-    onClick={[Function]}
-    type="button"
-  >
-    <svg
-      className="emotion-4"
-      viewBox="0 0 8 8"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g
-        fillRule="evenodd"
-        transform="translate(-4 -4)"
-      >
-        <path
-          d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
-          fillOpacity=".5"
-        />
-      </g>
-    </svg>
-  </button>
-</div>
-`;
-
-exports[`Alert renders correctly 1`] = `
-.emotion-7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
-  border-top: 4px solid;
-  border-radius: 0.375rem;
-  padding: 0.75rem 1.125rem;
-  background: #e9fafe;
-  border-color: #2875c6;
-}
-
-.emotion-2 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-0 {
-  font-size: 0.875rem;
-}
-
-.emotion-5 {
-  font-size: 1rem;
-  color: #0c0d0d;
-  background-color: rgba(12,13,13,0.1);
-  border-radius: 50%;
-  border: none;
-  cursor: pointer;
-  width: 1em;
-  height: 1em;
-  padding: 0;
-  position: relative;
-}
-
-.emotion-5:focus {
-  outline: none;
-}
-
-.emotion-4 {
-  width: 0.5em;
-  height: 0.5em;
-  fill: black;
-  position: absolute;
-  top: 0.25em;
-  left: 0.25em;
-  right: 0;
-  bottom: 0;
-}
-
-<div
-  className="emotion-7 emotion-8"
-  type="info"
->
-  <div
-    className="emotion-2 emotion-1"
-  >
-    <div
-      className="emotion-0 emotion-1"
-      fontSize="text-s"
-    >
-      Hello World
-    </div>
-  </div>
-  <button
-    className="emotion-5 emotion-6"
-    onClick={[Function]}
-    type="button"
-  >
-    <svg
-      className="emotion-4"
-      viewBox="0 0 8 8"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g
-        fillRule="evenodd"
-        transform="translate(-4 -4)"
-      >
-        <path
-          d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
-          fillOpacity=".5"
-        />
-      </g>
-    </svg>
-  </button>
-</div>
-`;
-
-exports[`Alert renders type danger correctly 1`] = `
-.emotion-2 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-0 {
-  font-size: 0.875rem;
-}
-
-.emotion-5 {
-  font-size: 1rem;
-  color: #0c0d0d;
-  background-color: rgba(12,13,13,0.1);
-  border-radius: 50%;
-  border: none;
-  cursor: pointer;
-  width: 1em;
-  height: 1em;
-  padding: 0;
-  position: relative;
-}
-
-.emotion-5:focus {
-  outline: none;
-}
-
-.emotion-4 {
-  width: 0.5em;
-  height: 0.5em;
-  fill: black;
-  position: absolute;
-  top: 0.25em;
-  left: 0.25em;
-  right: 0;
-  bottom: 0;
-}
-
-.emotion-7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
-  border-top: 4px solid;
-  border-radius: 0.375rem;
-  padding: 0.75rem 1.125rem;
-  background: #fee3e3;
-  border-color: #b93435;
-}
-
-<div
-  className="emotion-7 emotion-8"
-  type="danger"
->
-  <div
-    className="emotion-2 emotion-1"
-  >
-    <div
-      className="emotion-0 emotion-1"
-      fontSize="text-s"
-    >
-      Hello World
-    </div>
-  </div>
-  <button
-    className="emotion-5 emotion-6"
-    onClick={[Function]}
-    type="button"
-  >
-    <svg
-      className="emotion-4"
-      viewBox="0 0 8 8"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g
-        fillRule="evenodd"
-        transform="translate(-4 -4)"
-      >
-        <path
-          d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
-          fillOpacity=".5"
-        />
-      </g>
-    </svg>
-  </button>
-</div>
-`;
-
-exports[`Alert renders type info correctly 1`] = `
-.emotion-7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
-  border-top: 4px solid;
-  border-radius: 0.375rem;
-  padding: 0.75rem 1.125rem;
-  background: #e9fafe;
-  border-color: #2875c6;
-}
-
-.emotion-2 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-0 {
-  font-size: 0.875rem;
-}
-
-.emotion-5 {
-  font-size: 1rem;
-  color: #0c0d0d;
-  background-color: rgba(12,13,13,0.1);
-  border-radius: 50%;
-  border: none;
-  cursor: pointer;
-  width: 1em;
-  height: 1em;
-  padding: 0;
-  position: relative;
-}
-
-.emotion-5:focus {
-  outline: none;
-}
-
-.emotion-4 {
-  width: 0.5em;
-  height: 0.5em;
-  fill: black;
-  position: absolute;
-  top: 0.25em;
-  left: 0.25em;
-  right: 0;
-  bottom: 0;
-}
-
-<div
-  className="emotion-7 emotion-8"
-  type="info"
->
-  <div
-    className="emotion-2 emotion-1"
-  >
-    <div
-      className="emotion-0 emotion-1"
-      fontSize="text-s"
-    >
-      Hello World
-    </div>
-  </div>
-  <button
-    className="emotion-5 emotion-6"
-    onClick={[Function]}
-    type="button"
-  >
-    <svg
-      className="emotion-4"
-      viewBox="0 0 8 8"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g
-        fillRule="evenodd"
-        transform="translate(-4 -4)"
-      >
-        <path
-          d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
-          fillOpacity=".5"
-        />
-      </g>
-    </svg>
-  </button>
-</div>
-`;
-
-exports[`Alert renders type success correctly 1`] = `
-.emotion-2 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-0 {
-  font-size: 0.875rem;
-}
-
-.emotion-5 {
-  font-size: 1rem;
-  color: #0c0d0d;
-  background-color: rgba(12,13,13,0.1);
-  border-radius: 50%;
-  border: none;
-  cursor: pointer;
-  width: 1em;
-  height: 1em;
-  padding: 0;
-  position: relative;
-}
-
-.emotion-5:focus {
-  outline: none;
-}
-
-.emotion-4 {
-  width: 0.5em;
-  height: 0.5em;
-  fill: black;
-  position: absolute;
-  top: 0.25em;
-  left: 0.25em;
-  right: 0;
-  bottom: 0;
-}
-
-.emotion-7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
-  border-top: 4px solid;
-  border-radius: 0.375rem;
-  padding: 0.75rem 1.125rem;
-  background: #e0f8e6;
-  border-color: #26853f;
-}
-
-<div
-  className="emotion-7 emotion-8"
-  type="success"
->
-  <div
-    className="emotion-2 emotion-1"
-  >
-    <div
-      className="emotion-0 emotion-1"
-      fontSize="text-s"
-    >
-      Hello World
-    </div>
-  </div>
-  <button
-    className="emotion-5 emotion-6"
-    onClick={[Function]}
-    type="button"
-  >
-    <svg
-      className="emotion-4"
-      viewBox="0 0 8 8"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g
-        fillRule="evenodd"
-        transform="translate(-4 -4)"
-      >
-        <path
-          d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
-          fillOpacity=".5"
-        />
-      </g>
-    </svg>
-  </button>
-</div>
-`;
-
-exports[`Alert renders type warning correctly 1`] = `
-.emotion-2 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-0 {
-  font-size: 0.875rem;
-}
-
-.emotion-5 {
-  font-size: 1rem;
-  color: #0c0d0d;
-  background-color: rgba(12,13,13,0.1);
-  border-radius: 50%;
-  border: none;
-  cursor: pointer;
-  width: 1em;
-  height: 1em;
-  padding: 0;
-  position: relative;
-}
-
-.emotion-5:focus {
-  outline: none;
-}
-
-.emotion-4 {
-  width: 0.5em;
-  height: 0.5em;
-  fill: black;
-  position: absolute;
-  top: 0.25em;
-  left: 0.25em;
-  right: 0;
-  bottom: 0;
-}
-
-.emotion-7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
-  border-top: 4px solid;
-  border-radius: 0.375rem;
-  padding: 0.75rem 1.125rem;
-  background: #fdebd0;
-  border-color: #e69524;
-}
-
-<div
-  className="emotion-7 emotion-8"
-  type="warning"
->
-  <div
-    className="emotion-2 emotion-1"
-  >
-    <div
-      className="emotion-0 emotion-1"
-      fontSize="text-s"
-    >
-      Hello World
-    </div>
-  </div>
-  <button
-    className="emotion-5 emotion-6"
-    onClick={[Function]}
-    type="button"
-  >
-    <svg
-      className="emotion-4"
-      viewBox="0 0 8 8"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g
-        fillRule="evenodd"
-        transform="translate(-4 -4)"
-      >
-        <path
-          d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
-          fillOpacity=".5"
-        />
-      </g>
-    </svg>
-  </button>
-</div>
-`;
-
-exports[`Alert renders with a title 1`] = `
 .emotion-9 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -683,9 +109,19 @@ exports[`Alert renders with a title 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .emotion-2 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-0 {
   font-size: 0.875rem;
 }
 
@@ -717,6 +153,678 @@ exports[`Alert renders with a title 1`] = `
   bottom: 0;
 }
 
+<div
+  className="emotion-9 emotion-10"
+  type="info"
+>
+  <div
+    className="emotion-4 emotion-5"
+  >
+    <div
+      className="emotion-2 emotion-1"
+    >
+      <div
+        className="emotion-0 emotion-1"
+        fontSize="text-s"
+      >
+        300
+      </div>
+    </div>
+  </div>
+  <button
+    className="emotion-7 emotion-8"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      className="emotion-6"
+      viewBox="0 0 8 8"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fillRule="evenodd"
+        transform="translate(-4 -4)"
+      >
+        <path
+          d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
+          fillOpacity=".5"
+        />
+      </g>
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`Alert renders correctly 1`] = `
+.emotion-9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
+  border-top: 4px solid;
+  border-radius: 0.375rem;
+  padding: 0.75rem 1.125rem;
+  background: #e9fafe;
+  border-color: #2875c6;
+}
+
+.emotion-4 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-2 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-0 {
+  font-size: 0.875rem;
+}
+
+.emotion-7 {
+  font-size: 1rem;
+  color: #0c0d0d;
+  background-color: rgba(12,13,13,0.1);
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  width: 1em;
+  height: 1em;
+  padding: 0;
+  position: relative;
+}
+
+.emotion-7:focus {
+  outline: none;
+}
+
+.emotion-6 {
+  width: 0.5em;
+  height: 0.5em;
+  fill: black;
+  position: absolute;
+  top: 0.25em;
+  left: 0.25em;
+  right: 0;
+  bottom: 0;
+}
+
+<div
+  className="emotion-9 emotion-10"
+  type="info"
+>
+  <div
+    className="emotion-4 emotion-5"
+  >
+    <div
+      className="emotion-2 emotion-1"
+    >
+      <div
+        className="emotion-0 emotion-1"
+        fontSize="text-s"
+      >
+        Hello World
+      </div>
+    </div>
+  </div>
+  <button
+    className="emotion-7 emotion-8"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      className="emotion-6"
+      viewBox="0 0 8 8"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fillRule="evenodd"
+        transform="translate(-4 -4)"
+      >
+        <path
+          d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
+          fillOpacity=".5"
+        />
+      </g>
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`Alert renders type danger correctly 1`] = `
+.emotion-4 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-2 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-0 {
+  font-size: 0.875rem;
+}
+
+.emotion-7 {
+  font-size: 1rem;
+  color: #0c0d0d;
+  background-color: rgba(12,13,13,0.1);
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  width: 1em;
+  height: 1em;
+  padding: 0;
+  position: relative;
+}
+
+.emotion-7:focus {
+  outline: none;
+}
+
+.emotion-6 {
+  width: 0.5em;
+  height: 0.5em;
+  fill: black;
+  position: absolute;
+  top: 0.25em;
+  left: 0.25em;
+  right: 0;
+  bottom: 0;
+}
+
+.emotion-9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
+  border-top: 4px solid;
+  border-radius: 0.375rem;
+  padding: 0.75rem 1.125rem;
+  background: #fee3e3;
+  border-color: #b93435;
+}
+
+<div
+  className="emotion-9 emotion-10"
+  type="danger"
+>
+  <div
+    className="emotion-4 emotion-5"
+  >
+    <div
+      className="emotion-2 emotion-1"
+    >
+      <div
+        className="emotion-0 emotion-1"
+        fontSize="text-s"
+      >
+        Hello World
+      </div>
+    </div>
+  </div>
+  <button
+    className="emotion-7 emotion-8"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      className="emotion-6"
+      viewBox="0 0 8 8"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fillRule="evenodd"
+        transform="translate(-4 -4)"
+      >
+        <path
+          d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
+          fillOpacity=".5"
+        />
+      </g>
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`Alert renders type info correctly 1`] = `
+.emotion-9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
+  border-top: 4px solid;
+  border-radius: 0.375rem;
+  padding: 0.75rem 1.125rem;
+  background: #e9fafe;
+  border-color: #2875c6;
+}
+
+.emotion-4 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-2 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-0 {
+  font-size: 0.875rem;
+}
+
+.emotion-7 {
+  font-size: 1rem;
+  color: #0c0d0d;
+  background-color: rgba(12,13,13,0.1);
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  width: 1em;
+  height: 1em;
+  padding: 0;
+  position: relative;
+}
+
+.emotion-7:focus {
+  outline: none;
+}
+
+.emotion-6 {
+  width: 0.5em;
+  height: 0.5em;
+  fill: black;
+  position: absolute;
+  top: 0.25em;
+  left: 0.25em;
+  right: 0;
+  bottom: 0;
+}
+
+<div
+  className="emotion-9 emotion-10"
+  type="info"
+>
+  <div
+    className="emotion-4 emotion-5"
+  >
+    <div
+      className="emotion-2 emotion-1"
+    >
+      <div
+        className="emotion-0 emotion-1"
+        fontSize="text-s"
+      >
+        Hello World
+      </div>
+    </div>
+  </div>
+  <button
+    className="emotion-7 emotion-8"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      className="emotion-6"
+      viewBox="0 0 8 8"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fillRule="evenodd"
+        transform="translate(-4 -4)"
+      >
+        <path
+          d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
+          fillOpacity=".5"
+        />
+      </g>
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`Alert renders type success correctly 1`] = `
+.emotion-4 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-2 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-0 {
+  font-size: 0.875rem;
+}
+
+.emotion-7 {
+  font-size: 1rem;
+  color: #0c0d0d;
+  background-color: rgba(12,13,13,0.1);
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  width: 1em;
+  height: 1em;
+  padding: 0;
+  position: relative;
+}
+
+.emotion-7:focus {
+  outline: none;
+}
+
+.emotion-6 {
+  width: 0.5em;
+  height: 0.5em;
+  fill: black;
+  position: absolute;
+  top: 0.25em;
+  left: 0.25em;
+  right: 0;
+  bottom: 0;
+}
+
+.emotion-9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
+  border-top: 4px solid;
+  border-radius: 0.375rem;
+  padding: 0.75rem 1.125rem;
+  background: #e0f8e6;
+  border-color: #26853f;
+}
+
+<div
+  className="emotion-9 emotion-10"
+  type="success"
+>
+  <div
+    className="emotion-4 emotion-5"
+  >
+    <div
+      className="emotion-2 emotion-1"
+    >
+      <div
+        className="emotion-0 emotion-1"
+        fontSize="text-s"
+      >
+        Hello World
+      </div>
+    </div>
+  </div>
+  <button
+    className="emotion-7 emotion-8"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      className="emotion-6"
+      viewBox="0 0 8 8"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fillRule="evenodd"
+        transform="translate(-4 -4)"
+      >
+        <path
+          d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
+          fillOpacity=".5"
+        />
+      </g>
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`Alert renders type warning correctly 1`] = `
+.emotion-4 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-2 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-0 {
+  font-size: 0.875rem;
+}
+
+.emotion-7 {
+  font-size: 1rem;
+  color: #0c0d0d;
+  background-color: rgba(12,13,13,0.1);
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  width: 1em;
+  height: 1em;
+  padding: 0;
+  position: relative;
+}
+
+.emotion-7:focus {
+  outline: none;
+}
+
+.emotion-6 {
+  width: 0.5em;
+  height: 0.5em;
+  fill: black;
+  position: absolute;
+  top: 0.25em;
+  left: 0.25em;
+  right: 0;
+  bottom: 0;
+}
+
+.emotion-9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
+  border-top: 4px solid;
+  border-radius: 0.375rem;
+  padding: 0.75rem 1.125rem;
+  background: #fdebd0;
+  border-color: #e69524;
+}
+
+<div
+  className="emotion-9 emotion-10"
+  type="warning"
+>
+  <div
+    className="emotion-4 emotion-5"
+  >
+    <div
+      className="emotion-2 emotion-1"
+    >
+      <div
+        className="emotion-0 emotion-1"
+        fontSize="text-s"
+      >
+        Hello World
+      </div>
+    </div>
+  </div>
+  <button
+    className="emotion-7 emotion-8"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      className="emotion-6"
+      viewBox="0 0 8 8"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fillRule="evenodd"
+        transform="translate(-4 -4)"
+      >
+        <path
+          d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
+          fillOpacity=".5"
+        />
+      </g>
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`Alert renders with a title 1`] = `
+.emotion-11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
+  border-top: 4px solid;
+  border-radius: 0.375rem;
+  padding: 0.75rem 1.125rem;
+  background: #e9fafe;
+  border-color: #2875c6;
+}
+
+.emotion-6 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-4 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-2 {
+  font-size: 0.875rem;
+}
+
+.emotion-9 {
+  font-size: 1rem;
+  color: #0c0d0d;
+  background-color: rgba(12,13,13,0.1);
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  width: 1em;
+  height: 1em;
+  padding: 0;
+  position: relative;
+}
+
+.emotion-9:focus {
+  outline: none;
+}
+
+.emotion-8 {
+  width: 0.5em;
+  height: 0.5em;
+  fill: black;
+  position: absolute;
+  top: 0.25em;
+  left: 0.25em;
+  right: 0;
+  bottom: 0;
+}
+
 .emotion-0 {
   margin: 0;
   color: #0c0d0d;
@@ -730,34 +838,38 @@ exports[`Alert renders with a title 1`] = `
 }
 
 <div
-  className="emotion-9 emotion-10"
+  className="emotion-11 emotion-12"
   type="info"
 >
   <div
-    className="emotion-4 emotion-3"
+    className="emotion-6 emotion-7"
   >
-    <p
-      className="emotion-0 emotion-1"
-      color="textHeading"
-      fontSize="text"
-      fontWeight="bold"
-    >
-      My Title
-    </p>
     <div
-      className="emotion-2 emotion-3"
-      fontSize="text-s"
+      className="emotion-4 emotion-3"
     >
-      Hello World
+      <p
+        className="emotion-0 emotion-1"
+        color="textHeading"
+        fontSize="text"
+        fontWeight="bold"
+      >
+        My Title
+      </p>
+      <div
+        className="emotion-2 emotion-3"
+        fontSize="text-s"
+      >
+        Hello World
+      </div>
     </div>
   </div>
   <button
-    className="emotion-7 emotion-8"
+    className="emotion-9 emotion-10"
     onClick={[Function]}
     type="button"
   >
     <svg
-      className="emotion-6"
+      className="emotion-8"
       viewBox="0 0 8 8"
       xmlns="http://www.w3.org/2000/svg"
     >

--- a/packages/flame/src/Alert/index.tsx
+++ b/packages/flame/src/Alert/index.tsx
@@ -1,3 +1,3 @@
-import { Alert, AlertProps, AlertState } from './Alert';
+import { Alert, AlertProps } from './Alert';
 
-export { Alert, AlertProps, AlertState };
+export { Alert, AlertProps };

--- a/packages/flame/src/Alert/story.tsx
+++ b/packages/flame/src/Alert/story.tsx
@@ -4,6 +4,7 @@ import { withReadme } from 'storybook-readme';
 
 import { Alert } from './Alert';
 import { Text } from '../Text';
+import { IconWarning } from '../Icon/Warning';
 import Readme from './README.md';
 
 const stories = storiesOf('Alert', module).addDecorator(withReadme(Readme));
@@ -39,6 +40,11 @@ stories.add('Story', () => {
       <Alert title="Some Title" mb={2} noCloseBtn>
         <Text as="p" m={0}>
           This alert uses has no close button
+        </Text>
+      </Alert>
+      <Alert type="warning" icon={<IconWarning color="orange" />} title="Some Title" mb={2}>
+        <Text as="p" m={0}>
+          With icon
         </Text>
       </Alert>
     </div>


### PR DESCRIPTION
## Description
The current designs spec'd out for the `<Alert />` component it does not easily allow you to pass an icon for it. In order for devs to add these icons, they will need to completely ignore the `title` prop and implement the entire `<Alert />` body themselves (as proven by the implement within the internal design system documentation).

## Design specs
![image](https://user-images.githubusercontent.com/1291263/66134016-ed27c480-e5f7-11e9-8abf-dfa5bf0b0898.png)

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [x] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] When approved, I have run [visual regression tests](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#running-visual-regression-tests), got it approved and [posted a link](https://percy.io/Lightspeed/flame)
