### PR TITLE
Add Alert with Icon example in docs

### DIFF
--- a/packages/flame/src/Alert/README.md
+++ b/packages/flame/src/Alert/README.md
@@ -8,14 +8,14 @@ First, make sure you have been through the [Getting started](https://github.com/
 
 ### Props
 
-| Prop                  | Type                                      | Description                                |
-| --------------------- | ----------------------------------------- | ------------------------------------------ |
-| `type`                | `info`, `warning`, `danger`, or `success` | default is `info`                          |
-| `icon`                | `React.ReactNode`                         | An icon to place inside of the alert       |
-| `title`               | `string`                                  |                                            |
-| `onClose`             | `fn()`                                    | custom `fn(event)` passed the event object |
-| `noCloseBtn`          | `boolean`                                 |                                            |
-| `children` (required) | `any`                                     | The content of the alert                   |
+| Prop                  | Type                                      | Description                                                                                           |
+| --------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `type`                | `info`, `warning`, `danger`, or `success` | default is `info`                                                                                     |
+| `icon`                | `React.ReactNode`                         | An [icon](https://lightspeed-flame.netlify.com/?path=/story/icon--story) to place inside of the alert |
+| `title`               | `string`                                  |                                                                                                       |
+| `onClose`             | `fn()`                                    | custom `fn(event)` passed the event object                                                            |
+| `noCloseBtn`          | `boolean`                                 |                                                                                                       |
+| `children` (required) | `any`                                     | The content of the alert                                                                              |
 
 ### Styled System props
 
@@ -28,6 +28,7 @@ Available `styled-system` props:
 ```js
 import React from 'react';
 import { Alert } from '@lightspeed/flame/Alert';
+import { IconWarning } from '@lightspeed/flame/Icon/Warning';
 
 const MyComponent = () => (
   <div>
@@ -36,6 +37,9 @@ const MyComponent = () => (
     </Alert>
     <Alert type="info" title="My Title" mb={2}>
       Alert content with bottom margin
+    </Alert>
+    <Alert type="warning" icon={<IconWarning color="orange" />} title="My Title" mb={2}>
+      Alert content with icon
     </Alert>
   </div>
 );


### PR DESCRIPTION
## Description

Documenting what was added in #15.

<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->
<!-- Closes #XXX -->

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- I have added tests that prove my fix is effective or that my feature works
- When approved, I have run [visual regression tests](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#running-visual-regression-tests), got it approved and [posted a link](https://percy.io/Lightspeed/flame)
