### PR TITLE
Update Codecov target value

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,4 +3,4 @@ coverage:
   status:
     project:
       default:
-        target: auto
+        target: 90%

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,4 +3,4 @@ coverage:
   status:
     project:
       default:
-        target: 90%
+        target: auto

--- a/packages/flame/src/Core/__tests__/index.test.tsx
+++ b/packages/flame/src/Core/__tests__/index.test.tsx
@@ -1,0 +1,10 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { themeGet } from '../index';
+import { theme } from '../themes/flame';
+
+describe('Typed themeGet', () => {
+  it('should return the same value as themeGet for a given theme', () => {
+    const primaryColor = themeGet('colors.primary')({ theme });
+    expect(primaryColor).toBe(theme.colors.primary);
+  });
+});


### PR DESCRIPTION
## Description

Make it `90%` (currently at `~89%` on the repo) instead of `auto`. See https://docs.codecov.io/docs/commit-status#section-target for more info.

<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->
<!-- Closes #XXX -->

## How to test?

- Codecov commit status should show in the GitHub status checks

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [x] I have added tests that prove my fix is effective or that my feature works
- When approved, I have run [visual regression tests](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#running-visual-regression-tests), got it approved and [posted a link](https://percy.io/Lightspeed/flame)
