### PR TITLE
Fix weird typing generation caused by emotion + TS

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -11,7 +11,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ### Fixed
 
-- Removed component extension from Badge, as there seems to be a bug with the outputted types
+- Removed component extension from Badge, as there seems to be a bug with the outputted types ([#21](https://github.com/lightspeed/flame/pull/21))
 
 ## 0.3.0 - 2019-10-07
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Fixed
+
+- Removed component extension from Badge, as there seems to be a bug with the outputted types
+
 ## 0.3.0 - 2019-10-07
 
 ### Breaking

--- a/packages/flame/src/Badge/Badge.tsx
+++ b/packages/flame/src/Badge/Badge.tsx
@@ -56,7 +56,7 @@ export type BadgeProps = ColorProps & {
   size?: BadgeSizes;
 };
 
-export const Badge = styled('span')<React.HTMLAttributes<HTMLSpanElement> & BadgeProps>`
+export const Badge = styled('span')<React.HTMLAttributes<HTMLSpanElement> & Partial<BadgeProps>>`
   display: inline-flex;
   align-items: center;
   text-transform: uppercase;
@@ -73,12 +73,18 @@ Badge.defaultProps = {
   size: 'medium',
 };
 
-export const PillBadge = styled(Badge)<React.HTMLAttributes<HTMLSpanElement> & BadgeProps>(
-  setPillBadgeSizing,
-  css`
-    border-radius: 10rem;
-  `,
-);
+export const PillBadge = styled('span')<React.HTMLAttributes<HTMLSpanElement> & BadgeProps>`
+  display: inline-flex;
+  align-items: center;
+  text-transform: uppercase;
+  font-weight: bold;
+  border-radius: ${themeGet('radii.radius-1')};
+  ${badgeColors};
+  ${setBadgeSizing};
+  ${setPillBadgeSizing};
+  ${color};
+  border-radius: 10rem;
+`;
 
 PillBadge.defaultProps = {
   type: 'default',


### PR DESCRIPTION
## Description

For some reason, extending a component with emotion pumps wonky types with the `opacity` prop. Go figure...