### PR TITLE
Better mobile responsiveness for Checkbox/Radio

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -9,9 +9,9 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
-- Checkbox and Radio will now resize properly in mobile view ([#26](https://github.com/lightspeed/flame/pull/26))
+- Checkbox and Radio mobile view ([#26](https://github.com/lightspeed/flame/pull/26))
 
 ## 1.0.0 - 2019-10-08
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Fixed
+
+- Checkbox will now resize properly in mobile view
+- Radio will now resize properly in mobile view
+
 ## 1.0.0 - 2019-10-08
 
 - Flame is now considered stable :tada:

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -11,8 +11,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ### Fixed
 
-- Checkbox will now resize properly in mobile view ([#26](https://github.com/lightspeed/flame/pull/26))
-- Radio will now resize properly in mobile view ([#26](https://github.com/lightspeed/flame/pull/26))
+- Checkbox and Radio will now resize properly in mobile view ([#26](https://github.com/lightspeed/flame/pull/26))
 
 ## 1.0.0 - 2019-10-08
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -11,8 +11,8 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ### Fixed
 
-- Checkbox will now resize properly in mobile view
-- Radio will now resize properly in mobile view
+- Checkbox will now resize properly in mobile view ([#26](https://github.com/lightspeed/flame/pull/26))
+- Radio will now resize properly in mobile view ([#26](https://github.com/lightspeed/flame/pull/26))
 
 ## 1.0.0 - 2019-10-08
 

--- a/packages/flame/src/Checkbox/Checkbox.tsx
+++ b/packages/flame/src/Checkbox/Checkbox.tsx
@@ -143,7 +143,7 @@ export const CheckboxDescription: React.FC<CheckboxDescriptionProps> = ({
   color,
   ...restProps
 }) => (
-  <CheckboxDescriptionWrapper ml="1rem" color={color}>
+  <CheckboxDescriptionWrapper ml={['18px', '16px']} color={color}>
     <Text as="div" size="small" ml={2} {...restProps}>
       {children}
     </Text>

--- a/packages/flame/src/Checkbox/Checkbox.tsx
+++ b/packages/flame/src/Checkbox/Checkbox.tsx
@@ -117,7 +117,7 @@ CheckboxLabel.defaultProps = {
   ml: 2,
   fontWeight: 'bold',
   fontSize: ['text', 'text-s'],
-  lineHeight: [4, 3],
+  lineHeight: 3,
   as: 'div',
 };
 

--- a/packages/flame/src/Checkbox/Checkbox.tsx
+++ b/packages/flame/src/Checkbox/Checkbox.tsx
@@ -61,7 +61,7 @@ const StyledIcon = styled(IconCheckmark)<{ size: string }>`
   fill: ${themeGet('checkboxStyles.checked.color')};
 `;
 
-const CheckboxInput = styled('input')<LayoutProps & { indeterminate: boolean }>`
+const CheckboxInput = styled('input')<{ indeterminate: boolean }>`
   position: absolute;
   ${layout}
   top: 0;

--- a/packages/flame/src/Checkbox/Checkbox.tsx
+++ b/packages/flame/src/Checkbox/Checkbox.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { themeGet } from '@styled-system/theme-get';
+import { layout, LayoutProps } from 'styled-system';
 import { Merge } from 'type-fest';
 import { IconCheckmark } from '../Icon/Checkmark';
 import { Box } from '../Core';
@@ -17,10 +18,9 @@ const Label = styled('label')`
   display: inline-flex;
 `;
 
-const CheckboxCheckmarkWrapper = styled('div')<{ indeterminate: boolean }>`
+const CheckboxCheckmarkWrapper = styled('div')<LayoutProps & { indeterminate: boolean }>`
   position: relative;
-  width: 1rem;
-  height: 1rem;
+  ${layout};
   flex: 0 0 auto;
   border-radius: ${themeGet('radii.radius-1')};
   background-color: transparent;
@@ -36,6 +36,11 @@ const CheckboxCheckmarkWrapper = styled('div')<{ indeterminate: boolean }>`
       border-color: ${themeGet('checkboxStyles.indeterminate.border')(props)};
     `};
 `;
+
+CheckboxCheckmarkWrapper.defaultProps = {
+  width: ['18px', '16px'],
+  height: ['18px', '16px'],
+};
 
 const CheckboxIndeterminate = styled('div')`
   position: absolute;
@@ -56,10 +61,9 @@ const StyledIcon = styled(IconCheckmark)<{ size: string }>`
   fill: ${themeGet('checkboxStyles.checked.color')};
 `;
 
-const CheckboxInput = styled('input')<{ indeterminate: boolean }>`
+const CheckboxInput = styled('input')<LayoutProps & { indeterminate: boolean }>`
   position: absolute;
-  width: 1rem;
-  height: 1rem;
+  ${layout}
   top: 0;
   left: 0;
   opacity: 0;
@@ -93,6 +97,14 @@ const CheckboxInput = styled('input')<{ indeterminate: boolean }>`
   }
 `;
 
+CheckboxInput.defaultProps = {
+  // Fun clashing between legacy props and our custom props
+  // @ts-ignore
+  width: ['18px', '16px'],
+  // @ts-ignore
+  height: ['18px', '16px'],
+};
+
 export type CheckboxLabelProps = TextProps;
 export const CheckboxLabel = styled(Text)<CheckboxLabelProps>`
   ${props =>
@@ -104,7 +116,8 @@ export const CheckboxLabel = styled(Text)<CheckboxLabelProps>`
 CheckboxLabel.defaultProps = {
   ml: 2,
   fontWeight: 'bold',
-  size: 'small',
+  fontSize: ['text', 'text-s'],
+  lineHeight: [4, 3],
   as: 'div',
 };
 

--- a/packages/flame/src/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/flame/src/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -274,7 +274,13 @@ exports[`<Checkbox /> Snapshots when all props should render correctly 1`] = `
 }
 
 .emotion-13 {
-  margin-left: 1rem;
+  margin-left: 18px;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-13 {
+    margin-left: 16px;
+  }
 }
 
 .emotion-13 .emotion-12 {

--- a/packages/flame/src/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/flame/src/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -16,14 +16,21 @@ exports[`<Checkbox /> Snapshots when all props and label/description with html s
 
 .emotion-0 {
   position: absolute;
-  width: 1rem;
-  height: 1rem;
+  width: 18px;
+  height: 18px;
   top: 0;
   left: 0;
   opacity: 0;
   padding: 0;
   margin: 0;
   z-index: 1;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-0:checked + .emotion-6 {
@@ -53,8 +60,8 @@ exports[`<Checkbox /> Snapshots when all props and label/description with html s
 
 .emotion-5 {
   position: relative;
-  width: 1rem;
-  height: 1rem;
+  width: 18px;
+  height: 18px;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -65,6 +72,13 @@ exports[`<Checkbox /> Snapshots when all props and label/description with html s
   overflow: hidden;
   cursor: default;
   background: linear-gradient(180deg,#fff,#f3f3f3);
+}
+
+@media screen and (min-width:601px) {
+  .emotion-5 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-3 {
@@ -91,12 +105,36 @@ exports[`<Checkbox /> Snapshots when all props and label/description with html s
       aria-describedby="id-description"
       aria-labelledby="id-label"
       className="emotion-0 emotion-1"
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
       id="id"
       type="checkbox"
       value="value"
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     />
     <div
       className="emotion-5 emotion-6"
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     >
       <svg
         className="emotion-2 cr-icon emotion-3 emotion-4"
@@ -141,14 +179,21 @@ exports[`<Checkbox /> Snapshots when all props should render correctly 1`] = `
 
 .emotion-0 {
   position: absolute;
-  width: 1rem;
-  height: 1rem;
+  width: 18px;
+  height: 18px;
   top: 0;
   left: 0;
   opacity: 0;
   padding: 0;
   margin: 0;
   z-index: 1;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-0:checked + .emotion-6 {
@@ -178,8 +223,8 @@ exports[`<Checkbox /> Snapshots when all props should render correctly 1`] = `
 
 .emotion-5 {
   position: relative;
-  width: 1rem;
-  height: 1rem;
+  width: 18px;
+  height: 18px;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -190,6 +235,13 @@ exports[`<Checkbox /> Snapshots when all props should render correctly 1`] = `
   overflow: hidden;
   cursor: default;
   background: linear-gradient(180deg,#fff,#f3f3f3);
+}
+
+@media screen and (min-width:601px) {
+  .emotion-5 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-3 {
@@ -209,10 +261,17 @@ exports[`<Checkbox /> Snapshots when all props should render correctly 1`] = `
   margin: 0;
   margin-left: 0.75rem;
   font-weight: 700;
-  font-size: 0.875rem;
-  line-height: 1.125rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
   font-weight: 700;
   color: #0c0d0d;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-7 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
 }
 
 .emotion-13 {
@@ -241,12 +300,36 @@ exports[`<Checkbox /> Snapshots when all props should render correctly 1`] = `
       aria-describedby="id-description"
       aria-labelledby="id-label"
       className="emotion-0 emotion-1"
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
       id="id"
       type="checkbox"
       value="value"
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     />
     <div
       className="emotion-5 emotion-6"
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     >
       <svg
         className="emotion-2 cr-icon emotion-3 emotion-4"
@@ -267,9 +350,14 @@ exports[`<Checkbox /> Snapshots when all props should render correctly 1`] = `
     </div>
     <div
       className="emotion-7 emotion-8"
+      fontSize={
+        Array [
+          "text",
+          "text-s",
+        ]
+      }
       fontWeight="bold"
       id="id-label"
-      size="small"
     >
       Label
     </div>
@@ -304,14 +392,21 @@ exports[`<Checkbox /> Snapshots when checked should render correctly 1`] = `
 
 .emotion-0 {
   position: absolute;
-  width: 1rem;
-  height: 1rem;
+  width: 18px;
+  height: 18px;
   top: 0;
   left: 0;
   opacity: 0;
   padding: 0;
   margin: 0;
   z-index: 1;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-0:checked + .emotion-6 {
@@ -341,8 +436,8 @@ exports[`<Checkbox /> Snapshots when checked should render correctly 1`] = `
 
 .emotion-5 {
   position: relative;
-  width: 1rem;
-  height: 1rem;
+  width: 18px;
+  height: 18px;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -353,6 +448,13 @@ exports[`<Checkbox /> Snapshots when checked should render correctly 1`] = `
   overflow: hidden;
   cursor: default;
   background: linear-gradient(180deg,#fff,#f3f3f3);
+}
+
+@media screen and (min-width:601px) {
+  .emotion-5 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-3 {
@@ -380,11 +482,35 @@ exports[`<Checkbox /> Snapshots when checked should render correctly 1`] = `
       aria-labelledby={null}
       checked={true}
       className="emotion-0 emotion-1"
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
       onChange={[Function]}
       type="checkbox"
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     />
     <div
       className="emotion-5 emotion-6"
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     >
       <svg
         className="emotion-2 cr-icon emotion-3 emotion-4"
@@ -423,14 +549,21 @@ exports[`<Checkbox /> Snapshots when disabled should render correctly 1`] = `
 
 .emotion-0 {
   position: absolute;
-  width: 1rem;
-  height: 1rem;
+  width: 18px;
+  height: 18px;
   top: 0;
   left: 0;
   opacity: 0;
   padding: 0;
   margin: 0;
   z-index: 1;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-0:checked + .emotion-6 {
@@ -460,8 +593,8 @@ exports[`<Checkbox /> Snapshots when disabled should render correctly 1`] = `
 
 .emotion-5 {
   position: relative;
-  width: 1rem;
-  height: 1rem;
+  width: 18px;
+  height: 18px;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -472,6 +605,13 @@ exports[`<Checkbox /> Snapshots when disabled should render correctly 1`] = `
   overflow: hidden;
   cursor: default;
   background: linear-gradient(180deg,#fff,#f3f3f3);
+}
+
+@media screen and (min-width:601px) {
+  .emotion-5 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-3 {
@@ -499,10 +639,34 @@ exports[`<Checkbox /> Snapshots when disabled should render correctly 1`] = `
       aria-labelledby={null}
       className="emotion-0 emotion-1"
       disabled={true}
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
       type="checkbox"
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     />
     <div
       className="emotion-5 emotion-6"
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     >
       <svg
         className="emotion-2 cr-icon emotion-3 emotion-4"
@@ -541,14 +705,21 @@ exports[`<Checkbox /> Snapshots when empty props should render correctly 1`] = `
 
 .emotion-0 {
   position: absolute;
-  width: 1rem;
-  height: 1rem;
+  width: 18px;
+  height: 18px;
   top: 0;
   left: 0;
   opacity: 0;
   padding: 0;
   margin: 0;
   z-index: 1;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-0:checked + .emotion-6 {
@@ -578,8 +749,8 @@ exports[`<Checkbox /> Snapshots when empty props should render correctly 1`] = `
 
 .emotion-5 {
   position: relative;
-  width: 1rem;
-  height: 1rem;
+  width: 18px;
+  height: 18px;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -590,6 +761,13 @@ exports[`<Checkbox /> Snapshots when empty props should render correctly 1`] = `
   overflow: hidden;
   cursor: default;
   background: linear-gradient(180deg,#fff,#f3f3f3);
+}
+
+@media screen and (min-width:601px) {
+  .emotion-5 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-3 {
@@ -616,10 +794,34 @@ exports[`<Checkbox /> Snapshots when empty props should render correctly 1`] = `
       aria-describedby={null}
       aria-labelledby={null}
       className="emotion-0 emotion-1"
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
       type="checkbox"
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     />
     <div
       className="emotion-5 emotion-6"
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     >
       <svg
         className="emotion-2 cr-icon emotion-3 emotion-4"
@@ -658,14 +860,21 @@ exports[`<Checkbox /> Snapshots when indeterminate should render correctly 1`] =
 
 .emotion-0 {
   position: absolute;
-  width: 1rem;
-  height: 1rem;
+  width: 18px;
+  height: 18px;
   top: 0;
   left: 0;
   opacity: 0;
   padding: 0;
   margin: 0;
   z-index: 1;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-0:checked + .emotion-8 {
@@ -708,8 +917,8 @@ exports[`<Checkbox /> Snapshots when indeterminate should render correctly 1`] =
 
 .emotion-7 {
   position: relative;
-  width: 1rem;
-  height: 1rem;
+  width: 18px;
+  height: 18px;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -721,6 +930,13 @@ exports[`<Checkbox /> Snapshots when indeterminate should render correctly 1`] =
   cursor: default;
   background: linear-gradient(180deg,#fff,#f3f3f3);
   border-color: #2875c6;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-7 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-5 {
@@ -747,10 +963,34 @@ exports[`<Checkbox /> Snapshots when indeterminate should render correctly 1`] =
       aria-describedby={null}
       aria-labelledby={null}
       className="emotion-0 emotion-1"
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
       type="checkbox"
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     />
     <div
       className="emotion-7 emotion-8"
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     >
       <svg
         className="emotion-2 cr-icon emotion-3 emotion-4"
@@ -792,14 +1032,21 @@ exports[`<Checkbox /> Snapshots when not checked should render correctly 1`] = `
 
 .emotion-0 {
   position: absolute;
-  width: 1rem;
-  height: 1rem;
+  width: 18px;
+  height: 18px;
   top: 0;
   left: 0;
   opacity: 0;
   padding: 0;
   margin: 0;
   z-index: 1;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-0:checked + .emotion-6 {
@@ -829,8 +1076,8 @@ exports[`<Checkbox /> Snapshots when not checked should render correctly 1`] = `
 
 .emotion-5 {
   position: relative;
-  width: 1rem;
-  height: 1rem;
+  width: 18px;
+  height: 18px;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -841,6 +1088,13 @@ exports[`<Checkbox /> Snapshots when not checked should render correctly 1`] = `
   overflow: hidden;
   cursor: default;
   background: linear-gradient(180deg,#fff,#f3f3f3);
+}
+
+@media screen and (min-width:601px) {
+  .emotion-5 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-3 {
@@ -868,10 +1122,34 @@ exports[`<Checkbox /> Snapshots when not checked should render correctly 1`] = `
       aria-labelledby={null}
       checked={false}
       className="emotion-0 emotion-1"
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
       type="checkbox"
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     />
     <div
       className="emotion-5 emotion-6"
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     >
       <svg
         className="emotion-2 cr-icon emotion-3 emotion-4"

--- a/packages/flame/src/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/flame/src/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -262,7 +262,7 @@ exports[`<Checkbox /> Snapshots when all props should render correctly 1`] = `
   margin-left: 0.75rem;
   font-weight: 700;
   font-size: 1rem;
-  line-height: 1.5rem;
+  line-height: 1.125rem;
   font-weight: 700;
   color: #0c0d0d;
 }
@@ -270,7 +270,6 @@ exports[`<Checkbox /> Snapshots when all props should render correctly 1`] = `
 @media screen and (min-width:601px) {
   .emotion-7 {
     font-size: 0.875rem;
-    line-height: 1.125rem;
   }
 }
 

--- a/packages/flame/src/Checkbox/story.tsx
+++ b/packages/flame/src/Checkbox/story.tsx
@@ -5,6 +5,7 @@ import { withReadme } from 'storybook-readme';
 
 import { Heading2, Heading3, TextContent } from '../Text';
 import { Box } from '../Core';
+import { percyBreakpoints, percySkip } from '../../../../stories/helpers/percy';
 
 import { Checkbox, CheckboxLabel, CheckboxDescription, CheckboxProps } from './Checkbox';
 import Readme from './README.md';
@@ -91,74 +92,80 @@ class CheckBoxWrapper extends React.Component<{}, { checked: boolean; indetermin
   }
 }
 
-stories.add('Story', () => (
-  <div>
-    <TextContent>
-      <Heading2>Checkbox types</Heading2>
-      <Heading3>Checkbox with label</Heading3>
-      <Box mb={3}>
-        <StatefulCheckbox id="simple" label="Label" />
-      </Box>
-      <Heading3>Checkbox with label and description</Heading3>
-      <Box mb={3}>
-        <StatefulCheckbox id="checked" label="Label" description="Description text" checked />
-      </Box>
-      <Heading3>Checkbox with long label and description in a 50% container</Heading3>
-      <Box mb={3} style={{ width: '50%' }}>
-        <StatefulCheckbox
-          id="longLabel"
-          label="Long Label Long Label Long Label Long Label Long Label Long Label Long Label Long Label Long Label"
-          description="Long Description Long Description Long Description Long Description Long Description Long Description Long Description Long Description"
-          indeterminate
-        />
-      </Box>
-      <Heading3>Using custom elements</Heading3>
-      <Box mb={3}>
-        <StatefulCheckbox
-          id="longLabel"
-          label={() => (
-            <CheckboxLabel ml="4" width="100%" color="red" fontWeight="normal">
-              Customizing the base exported `CheckboxLabel`
-            </CheckboxLabel>
-          )}
-          description={() => (
-            <CheckboxDescription color="blue" ml={4} mt={1} size="large">
-              Customizing the base exported `CheckboxDescription`
-            </CheckboxDescription>
-          )}
-        />
-      </Box>
-    </TextContent>
+stories.add(
+  'Story',
+  () => (
+    <div>
+      <TextContent>
+        <Heading2>Checkbox types</Heading2>
+        <Heading3>Checkbox with label</Heading3>
+        <Box mb={3}>
+          <StatefulCheckbox id="simple" label="Label" />
+        </Box>
+        <Heading3>Checkbox with label and description</Heading3>
+        <Box mb={3}>
+          <StatefulCheckbox id="checked" label="Label" description="Description text" checked />
+        </Box>
+        <Heading3>Checkbox with long label and description in a 50% container</Heading3>
+        <Box mb={3} style={{ width: '50%' }}>
+          <StatefulCheckbox
+            id="longLabel"
+            label="Long Label Long Label Long Label Long Label Long Label Long Label Long Label Long Label Long Label"
+            description="Long Description Long Description Long Description Long Description Long Description Long Description Long Description Long Description"
+            indeterminate
+          />
+        </Box>
+        <Heading3>Using custom elements</Heading3>
+        <Box mb={3}>
+          <StatefulCheckbox
+            id="longLabel"
+            label={() => (
+              <CheckboxLabel ml="4" width="100%" color="red" fontWeight="normal">
+                Customizing the base exported `CheckboxLabel`
+              </CheckboxLabel>
+            )}
+            description={() => (
+              <CheckboxDescription color="blue" ml={4} mt={1} size="large">
+                Customizing the base exported `CheckboxDescription`
+              </CheckboxDescription>
+            )}
+          />
+        </Box>
+      </TextContent>
 
-    <TextContent>
-      <Heading2>Checkbox states</Heading2>
+      <TextContent>
+        <Heading2>Checkbox states</Heading2>
 
-      <Box mb={3}>
-        <StatefulCheckbox id="unchecked" label="Unchecked" />
-      </Box>
-      <Box mb={3}>
-        <StatefulCheckbox id="indeterminate" label="Indeterminate" indeterminate />
-      </Box>
-      <Box mb={3}>
-        <StatefulCheckbox id="checked" label="Checked" checked />
-      </Box>
-      <Box mb={3}>
-        <StatefulCheckbox id="disabled" label="Disabled" disabled />
-      </Box>
-      <Box mb={3}>
-        <StatefulCheckbox
-          id="indeterminate-disabled"
-          label="Indeterminate Disabled"
-          indeterminate
-          disabled
-        />
-      </Box>
-      <Box mb={3}>
-        <StatefulCheckbox id="checked-disabled" label="Checked Disabled" checked disabled />
-      </Box>
-    </TextContent>
-  </div>
-));
+        <Box mb={3}>
+          <StatefulCheckbox id="unchecked" label="Unchecked" />
+        </Box>
+        <Box mb={3}>
+          <StatefulCheckbox id="indeterminate" label="Indeterminate" indeterminate />
+        </Box>
+        <Box mb={3}>
+          <StatefulCheckbox id="checked" label="Checked" checked />
+        </Box>
+        <Box mb={3}>
+          <StatefulCheckbox id="disabled" label="Disabled" disabled />
+        </Box>
+        <Box mb={3}>
+          <StatefulCheckbox
+            id="indeterminate-disabled"
+            label="Indeterminate Disabled"
+            indeterminate
+            disabled
+          />
+        </Box>
+        <Box mb={3}>
+          <StatefulCheckbox id="checked-disabled" label="Checked Disabled" checked disabled />
+        </Box>
+      </TextContent>
+    </div>
+  ),
+  {
+    ...percyBreakpoints,
+  },
+);
 
 stories.add(
   'Events',
@@ -192,5 +199,5 @@ stories.add(
       </TextContent>
     </div>
   ),
-  { percy: { skip: true } },
+  { ...percySkip },
 );

--- a/packages/flame/src/Radio/Radio.tsx
+++ b/packages/flame/src/Radio/Radio.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { themeGet } from '@styled-system/theme-get';
+import { layout, LayoutProps } from 'styled-system';
 import { Merge } from 'type-fest';
 
 import { Text, TextProps } from '../Text';
@@ -17,10 +18,11 @@ const Label = styled('label')`
   display: inline-flex;
 `;
 
-const Checkmark = styled('div')`
+const Checkmark = styled('div')<LayoutProps>`
   position: relative;
   width: 1rem;
   height: 1rem;
+  ${layout};
   flex: 0 0 auto;
   border-radius: ${themeGet('radii.radius-circle')};
   background-color: transparent;
@@ -30,21 +32,29 @@ const Checkmark = styled('div')`
   background: ${themeGet('radioStyles.background')};
 `;
 
-const Centermark = styled('div')`
+Checkmark.defaultProps = {
+  width: ['18px', '16px'],
+  height: ['18px', '16px'],
+};
+
+const Centermark = styled('div')<LayoutProps>`
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: ${themeGet('space.1')};
-  height: ${themeGet('space.1')};
+  ${layout};
   border-radius: ${themeGet('radii.radius-circle')};
   background: ${themeGet('radioStyles.background')};
 `;
 
+Centermark.defaultProps = {
+  width: ['7px', '6px'],
+  height: ['7px', '6px'],
+};
+
 const RadioInput = styled('input')`
   position: absolute;
-  width: 1rem;
-  height: 1rem;
+  ${layout};
   top: 0;
   left: 0;
   opacity: 0;
@@ -71,6 +81,14 @@ const RadioInput = styled('input')`
   }
 `;
 
+RadioInput.defaultProps = {
+  // Fun clashing between legacy props and our custom props
+  // @ts-ignore
+  width: ['18px', '16px'],
+  // @ts-ignore
+  height: ['18px', '16px'],
+};
+
 export const RadioLabel = styled(Text)`
   ${props =>
     !props.color &&
@@ -80,7 +98,8 @@ export const RadioLabel = styled(Text)`
 `.withComponent('div');
 
 RadioLabel.defaultProps = {
-  size: 'small',
+  fontSize: ['text', 'text-s'],
+  lineHeight: [4, 3],
   fontWeight: 'bold',
   ml: 2,
 };

--- a/packages/flame/src/Radio/Radio.tsx
+++ b/packages/flame/src/Radio/Radio.tsx
@@ -126,7 +126,7 @@ export const RadioDescription: React.FC<RadioDescriptionProps> = ({
   color,
   ...restProps
 }) => (
-  <RadioDescriptionWrapper ml="1rem" color={color}>
+  <RadioDescriptionWrapper ml={['18px', '16px']} color={color}>
     <Text as="div" size="small" ml={2} {...restProps}>
       {children}
     </Text>

--- a/packages/flame/src/Radio/Radio.tsx
+++ b/packages/flame/src/Radio/Radio.tsx
@@ -99,7 +99,7 @@ export const RadioLabel = styled(Text)`
 
 RadioLabel.defaultProps = {
   fontSize: ['text', 'text-s'],
-  lineHeight: [4, 3],
+  lineHeight: 3,
   fontWeight: 'bold',
   ml: 2,
 };

--- a/packages/flame/src/Radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/flame/src/Radio/__snapshots__/Radio.test.tsx.snap
@@ -112,7 +112,13 @@ exports[`<Radio /> Snapshots renders a Radio with a label and description correc
 }
 
 .emotion-12 {
-  margin-left: 1rem;
+  margin-left: 18px;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-12 {
+    margin-left: 16px;
+  }
 }
 
 .emotion-12 .emotion-11 {

--- a/packages/flame/src/Radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/flame/src/Radio/__snapshots__/Radio.test.tsx.snap
@@ -16,14 +16,21 @@ exports[`<Radio /> Snapshots renders a Radio with a label and description correc
 
 .emotion-0 {
   position: absolute;
-  width: 1rem;
-  height: 1rem;
+  width: 18px;
+  height: 18px;
   top: 0;
   left: 0;
   opacity: 0;
   padding: 0;
   margin: 0;
   z-index: 1;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-0:checked + .emotion-5 {
@@ -48,6 +55,8 @@ exports[`<Radio /> Snapshots renders a Radio with a label and description correc
   position: relative;
   width: 1rem;
   height: 1rem;
+  width: 18px;
+  height: 18px;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -59,6 +68,13 @@ exports[`<Radio /> Snapshots renders a Radio with a label and description correc
   background: #fff linear-gradient(180deg,#fff,#f3f3f3);
 }
 
+@media screen and (min-width:601px) {
+  .emotion-4 {
+    width: 16px;
+    height: 16px;
+  }
+}
+
 .emotion-2 {
   position: absolute;
   top: 50%;
@@ -66,20 +82,34 @@ exports[`<Radio /> Snapshots renders a Radio with a label and description correc
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  width: 0.375rem;
-  height: 0.375rem;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   background: #fff linear-gradient(180deg,#fff,#f3f3f3);
 }
 
+@media screen and (min-width:601px) {
+  .emotion-2 {
+    width: 6px;
+    height: 6px;
+  }
+}
+
 .emotion-6 {
   margin: 0;
+  font-size: 1rem;
+  line-height: 1.5rem;
   font-weight: 700;
   margin-left: 0.75rem;
-  font-size: 0.875rem;
-  line-height: 1.125rem;
   font-weight: 700;
   color: #0c0d0d;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-6 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
 }
 
 .emotion-12 {
@@ -110,24 +140,65 @@ exports[`<Radio /> Snapshots renders a Radio with a label and description correc
       aria-labelledby="Radio-label"
       checked={false}
       className="emotion-0 emotion-1"
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
       id="Radio"
       onChange={[MockFunction]}
       type="radio"
       value="value"
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     />
     <div
       className="emotion-4 emotion-5"
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     >
       <div
         className="emotion-2 emotion-3"
         data-testid="radio-centermark"
+        height={
+          Array [
+            "7px",
+            "6px",
+          ]
+        }
+        width={
+          Array [
+            "7px",
+            "6px",
+          ]
+        }
       />
     </div>
     <div
       className="emotion-6 emotion-7"
+      fontSize={
+        Array [
+          "text",
+          "text-s",
+        ]
+      }
       fontWeight="bold"
       id="Radio-label"
-      size="small"
     >
       Label
     </div>
@@ -162,14 +233,21 @@ exports[`<Radio /> Snapshots renders a checked Radio correctly 1`] = `
 
 .emotion-0 {
   position: absolute;
-  width: 1rem;
-  height: 1rem;
+  width: 18px;
+  height: 18px;
   top: 0;
   left: 0;
   opacity: 0;
   padding: 0;
   margin: 0;
   z-index: 1;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-0:checked + .emotion-5 {
@@ -194,6 +272,8 @@ exports[`<Radio /> Snapshots renders a checked Radio correctly 1`] = `
   position: relative;
   width: 1rem;
   height: 1rem;
+  width: 18px;
+  height: 18px;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -205,6 +285,13 @@ exports[`<Radio /> Snapshots renders a checked Radio correctly 1`] = `
   background: #fff linear-gradient(180deg,#fff,#f3f3f3);
 }
 
+@media screen and (min-width:601px) {
+  .emotion-4 {
+    width: 16px;
+    height: 16px;
+  }
+}
+
 .emotion-2 {
   position: absolute;
   top: 50%;
@@ -212,10 +299,17 @@ exports[`<Radio /> Snapshots renders a checked Radio correctly 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  width: 0.375rem;
-  height: 0.375rem;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   background: #fff linear-gradient(180deg,#fff,#f3f3f3);
+}
+
+@media screen and (min-width:601px) {
+  .emotion-2 {
+    width: 6px;
+    height: 6px;
+  }
 }
 
 <div
@@ -231,17 +325,53 @@ exports[`<Radio /> Snapshots renders a checked Radio correctly 1`] = `
       aria-labelledby={null}
       checked={true}
       className="emotion-0 emotion-1"
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
       id="Radio"
       onChange={[MockFunction]}
       type="radio"
       value="value"
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     />
     <div
       className="emotion-4 emotion-5"
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     >
       <div
         className="emotion-2 emotion-3"
         data-testid="radio-centermark"
+        height={
+          Array [
+            "7px",
+            "6px",
+          ]
+        }
+        width={
+          Array [
+            "7px",
+            "6px",
+          ]
+        }
       />
     </div>
   </label>
@@ -264,14 +394,21 @@ exports[`<Radio /> Snapshots renders a disabled Radio correctly 1`] = `
 
 .emotion-0 {
   position: absolute;
-  width: 1rem;
-  height: 1rem;
+  width: 18px;
+  height: 18px;
   top: 0;
   left: 0;
   opacity: 0;
   padding: 0;
   margin: 0;
   z-index: 1;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-0:checked + .emotion-5 {
@@ -296,6 +433,8 @@ exports[`<Radio /> Snapshots renders a disabled Radio correctly 1`] = `
   position: relative;
   width: 1rem;
   height: 1rem;
+  width: 18px;
+  height: 18px;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -307,6 +446,13 @@ exports[`<Radio /> Snapshots renders a disabled Radio correctly 1`] = `
   background: #fff linear-gradient(180deg,#fff,#f3f3f3);
 }
 
+@media screen and (min-width:601px) {
+  .emotion-4 {
+    width: 16px;
+    height: 16px;
+  }
+}
+
 .emotion-2 {
   position: absolute;
   top: 50%;
@@ -314,10 +460,17 @@ exports[`<Radio /> Snapshots renders a disabled Radio correctly 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  width: 0.375rem;
-  height: 0.375rem;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   background: #fff linear-gradient(180deg,#fff,#f3f3f3);
+}
+
+@media screen and (min-width:601px) {
+  .emotion-2 {
+    width: 6px;
+    height: 6px;
+  }
 }
 
 <div
@@ -334,17 +487,53 @@ exports[`<Radio /> Snapshots renders a disabled Radio correctly 1`] = `
       checked={false}
       className="emotion-0 emotion-1"
       disabled={true}
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
       id="Radio"
       onChange={[MockFunction]}
       type="radio"
       value="value"
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     />
     <div
       className="emotion-4 emotion-5"
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     >
       <div
         className="emotion-2 emotion-3"
         data-testid="radio-centermark"
+        height={
+          Array [
+            "7px",
+            "6px",
+          ]
+        }
+        width={
+          Array [
+            "7px",
+            "6px",
+          ]
+        }
       />
     </div>
   </label>
@@ -367,14 +556,21 @@ exports[`<Radio /> Snapshots renders a simple Radio correctly 1`] = `
 
 .emotion-0 {
   position: absolute;
-  width: 1rem;
-  height: 1rem;
+  width: 18px;
+  height: 18px;
   top: 0;
   left: 0;
   opacity: 0;
   padding: 0;
   margin: 0;
   z-index: 1;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-0:checked + .emotion-5 {
@@ -399,6 +595,8 @@ exports[`<Radio /> Snapshots renders a simple Radio correctly 1`] = `
   position: relative;
   width: 1rem;
   height: 1rem;
+  width: 18px;
+  height: 18px;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -410,6 +608,13 @@ exports[`<Radio /> Snapshots renders a simple Radio correctly 1`] = `
   background: #fff linear-gradient(180deg,#fff,#f3f3f3);
 }
 
+@media screen and (min-width:601px) {
+  .emotion-4 {
+    width: 16px;
+    height: 16px;
+  }
+}
+
 .emotion-2 {
   position: absolute;
   top: 50%;
@@ -417,10 +622,17 @@ exports[`<Radio /> Snapshots renders a simple Radio correctly 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  width: 0.375rem;
-  height: 0.375rem;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   background: #fff linear-gradient(180deg,#fff,#f3f3f3);
+}
+
+@media screen and (min-width:601px) {
+  .emotion-2 {
+    width: 6px;
+    height: 6px;
+  }
 }
 
 <div
@@ -435,15 +647,51 @@ exports[`<Radio /> Snapshots renders a simple Radio correctly 1`] = `
       aria-labelledby={null}
       checked={false}
       className="emotion-0 emotion-1"
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
       onChange={[MockFunction]}
       type="radio"
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     />
     <div
       className="emotion-4 emotion-5"
+      height={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
+      width={
+        Array [
+          "18px",
+          "16px",
+        ]
+      }
     >
       <div
         className="emotion-2 emotion-3"
         data-testid="radio-centermark"
+        height={
+          Array [
+            "7px",
+            "6px",
+          ]
+        }
+        width={
+          Array [
+            "7px",
+            "6px",
+          ]
+        }
       />
     </div>
   </label>

--- a/packages/flame/src/Radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/flame/src/Radio/__snapshots__/Radio.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`<Radio /> Snapshots renders a Radio with a label and description correc
 .emotion-6 {
   margin: 0;
   font-size: 1rem;
-  line-height: 1.5rem;
+  line-height: 1.125rem;
   font-weight: 700;
   margin-left: 0.75rem;
   font-weight: 700;
@@ -108,7 +108,6 @@ exports[`<Radio /> Snapshots renders a Radio with a label and description correc
 @media screen and (min-width:601px) {
   .emotion-6 {
     font-size: 0.875rem;
-    line-height: 1.125rem;
   }
 }
 

--- a/packages/flame/src/Radio/story.tsx
+++ b/packages/flame/src/Radio/story.tsx
@@ -7,81 +7,86 @@ import { Text, Heading2, Heading3, TextContent } from '../Text';
 import RadioWrapper from './examples';
 import { Radio, RadioLabel, RadioDescription } from './Radio';
 import { Box } from '../Core';
+import { percyBreakpoints, percySkip } from '../../../../stories/helpers/percy';
 
 import Readme from './README.md';
 
 const stories = storiesOf('Radio', module).addDecorator(withReadme(Readme));
 
-stories.add('Story', () => (
-  <div>
-    <TextContent>
-      <Heading2>Radio types</Heading2>
-      <Heading3>Radio with label</Heading3>
-      <Box mb={3}>
-        <Radio id="simple" label="Label" checked={false} onChange={() => {}} />
-      </Box>
-      <Heading3>Radio with label and description</Heading3>
-      <Box mb={3}>
-        <Radio
-          id="checked"
-          label="Label"
-          description="Description text"
-          checked
-          onChange={() => {}}
-        />
-      </Box>
-      <Heading3>Radio with long label and description in a 50% container</Heading3>
-      <Box mb={3} style={{ width: '50%' }}>
-        <Radio
-          id="longLabel"
-          label="Long Label Long Label Long Label Long Label Long Label Long Label Long Label Long Label Long Label"
-          description="Long Description Long Description Long Description Long Description Long Description Long Description Long Description Long Description"
-          checked={false}
-          onChange={() => {}}
-        />
-      </Box>
-      <Heading3>Using custom elements</Heading3>
-      <Box mb={3}>
-        <Radio
-          id="longLabel"
-          label={() => (
-            <RadioLabel ml="4" width="100%" color="red" fontWeight="normal">
-              Customizing the base exported `RadioLabel`
-            </RadioLabel>
-          )}
-          description={() => (
-            <RadioDescription color="blue" ml={4} mt={1} size="large">
-              Customizing the base exported `RadioDescription`
-            </RadioDescription>
-          )}
-          checked={false}
-          onChange={() => {}}
-        />
-      </Box>
-    </TextContent>
-    <TextContent>
-      <Heading2>Radio states</Heading2>
-      <Box mb={3}>
-        <Radio id="unchecked" label="Unchecked" checked={false} onChange={() => {}} />
-      </Box>
-      <Box mb={3}>
-        <Radio id="checked" label="Checked" checked onChange={() => {}} />
-      </Box>
-      <Box mb={3}>
-        <Radio id="disabled" label="Disabled" disabled checked={false} onChange={() => {}} />
-      </Box>
-      <Box mb={3}>
-        <Radio
-          id="checked-disabled"
-          label="Checked Disabled"
-          checked
-          onChange={() => {}}
-          disabled
-        />
-      </Box>
-    </TextContent>
-  </div>
-));
+stories.add(
+  'Story',
+  () => (
+    <div>
+      <TextContent>
+        <Heading2>Radio types</Heading2>
+        <Heading3>Radio with label</Heading3>
+        <Box mb={3}>
+          <Radio id="simple" label="Label" checked={false} onChange={() => {}} />
+        </Box>
+        <Heading3>Radio with label and description</Heading3>
+        <Box mb={3}>
+          <Radio
+            id="checked"
+            label="Label"
+            description="Description text"
+            checked
+            onChange={() => {}}
+          />
+        </Box>
+        <Heading3>Radio with long label and description in a 50% container</Heading3>
+        <Box mb={3} style={{ width: '50%' }}>
+          <Radio
+            id="longLabel"
+            label="Long Label Long Label Long Label Long Label Long Label Long Label Long Label Long Label Long Label"
+            description="Long Description Long Description Long Description Long Description Long Description Long Description Long Description Long Description"
+            checked={false}
+            onChange={() => {}}
+          />
+        </Box>
+        <Heading3>Using custom elements</Heading3>
+        <Box mb={3}>
+          <Radio
+            id="longLabel"
+            label={() => (
+              <RadioLabel ml="4" width="100%" color="red" fontWeight="normal">
+                Customizing the base exported `RadioLabel`
+              </RadioLabel>
+            )}
+            description={() => (
+              <RadioDescription color="blue" ml={4} mt={1} size="large">
+                Customizing the base exported `RadioDescription`
+              </RadioDescription>
+            )}
+            checked={false}
+            onChange={() => {}}
+          />
+        </Box>
+      </TextContent>
+      <TextContent>
+        <Heading2>Radio states</Heading2>
+        <Box mb={3}>
+          <Radio id="unchecked" label="Unchecked" checked={false} onChange={() => {}} />
+        </Box>
+        <Box mb={3}>
+          <Radio id="checked" label="Checked" checked onChange={() => {}} />
+        </Box>
+        <Box mb={3}>
+          <Radio id="disabled" label="Disabled" disabled checked={false} onChange={() => {}} />
+        </Box>
+        <Box mb={3}>
+          <Radio
+            id="checked-disabled"
+            label="Checked Disabled"
+            checked
+            onChange={() => {}}
+            disabled
+          />
+        </Box>
+      </TextContent>
+    </div>
+  ),
+  { ...percyBreakpoints },
+);
 
 stories.add(
   'Uncontrolled state',
@@ -99,7 +104,7 @@ stories.add(
       </Box>
     </TextContent>
   ),
-  { percy: { skip: true } },
+  { ...percySkip },
 );
 
 stories.add(
@@ -151,5 +156,5 @@ stories.add(
       </Box>
     </TextContent>
   ),
-  { percy: { skip: true } },
+  { ...percySkip },
 );

--- a/stories/helpers/percy.ts
+++ b/stories/helpers/percy.ts
@@ -1,0 +1,10 @@
+import { commonTheme } from '../../packages/flame-tokens/src/theme-ui/common';
+
+const integerBreakpoints = commonTheme.breakpoints.map(v =>
+  Number.parseInt(v.replace('px', ''), 10),
+);
+
+const percyBreakpoints = { percy: { widths: integerBreakpoints } };
+const percySkip = { percy: { skip: true } };
+
+export { percyBreakpoints, percySkip };


### PR DESCRIPTION
## Description

Added some styled-system props and used the whole array notation to ensure the right values get used in mobile.

Needed to go with hard coded values instead of theme values to match up proposed design specs. 6 point scale means we cannot reliably get the values for 1rem, so this will do for now.

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [x] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] When approved, I have run [visual regression tests](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#running-visual-regression-tests), got it approved and [posted a link](https://percy.io/Lightspeed/flame)
