### PR TITLE
Mobile friendly Alert & Icon

### DIFF
--- a/packages/flame/src/Alert/Alert.tsx
+++ b/packages/flame/src/Alert/Alert.tsx
@@ -11,7 +11,7 @@ const alertStyles = variant({
   prop: 'type',
 });
 
-const AlertWrapper = styled('div')<{ type: string }>`
+const AlertWrapper = styled('div')<SpaceProps & { type: string }>`
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
@@ -19,13 +19,14 @@ const AlertWrapper = styled('div')<{ type: string }>`
     0 1px 2px 0 rgba(0, 0, 0, 0.1);
   border-top: 4px solid;
   border-radius: ${themeGet('radii.radius-2')};
-  padding: ${themeGet('space.2')} ${themeGet('space.3')};
   ${space}
   ${alertStyles}
 `;
 
 AlertWrapper.defaultProps = {
   type: 'info',
+  px: 3,
+  py: [3, 2],
 };
 
 const CloseButton = styled('button')<LayoutProps>`

--- a/packages/flame/src/Alert/Alert.tsx
+++ b/packages/flame/src/Alert/Alert.tsx
@@ -29,7 +29,7 @@ AlertWrapper.defaultProps = {
   py: [3, 2],
 };
 
-const CloseButton = styled('button')<LayoutProps>`
+const CloseButton = styled('button')<LayoutProps & SpaceProps>`
   font-size: ${themeGet('fontSizes.text')};
   color: ${themeGet('colors.textHeading')};
   background-color: ${props => transparentize(0.9, themeGet('colors.textHeading', '#000')(props))};
@@ -89,51 +89,57 @@ const Alert: React.FunctionComponent<AlertProps & SpaceProps> = ({
     <AlertWrapper type={type} {...restProps}>
       <Flex flex="1" alignItems="flex-start">
         {icon && (
-          <Flex alignItems="center" pr={2} pt="2px">
+          <Box lineHeight={4} pr={2}>
             {icon}
-          </Flex>
+          </Box>
         )}
         <Box flex="1">
-          {title && (
-            <Text
-              color="textHeading"
-              fontWeight="bold"
-              fontSize={['text-l', 'text']}
-              mt={0}
-              mr={0}
-              mb={0}
-              ml={0}
-            >
-              {title}
-            </Text>
-          )}
+          <Flex alignItems="center">
+            {title && (
+              <Box flex="1">
+                <Text
+                  color="textHeading"
+                  fontWeight="bold"
+                  lineHeight={4}
+                  fontSize={['text-l', 'text']}
+                  mt={0}
+                  mr={0}
+                  mb={0}
+                  ml={0}
+                >
+                  {title}
+                </Text>
+              </Box>
+            )}
+            {!noCloseBtn && (
+              <CloseButton type="button" onClick={handleClose}>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 8 8"
+                  css={{
+                    width: '0.5em',
+                    height: '0.5em',
+                    fill: 'black',
+                    position: 'absolute',
+                    top: '50%',
+                    left: '50%',
+                    transform: 'translate(-50%, -50%)',
+                  }}
+                >
+                  <g fillRule="evenodd" transform="translate(-4 -4)">
+                    <path
+                      fillOpacity=".5"
+                      d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
+                    />
+                  </g>
+                </svg>
+              </CloseButton>
+            )}
+          </Flex>
+
           <Box fontSize={['text', 'text-s']}>{children}</Box>
         </Box>
       </Flex>
-      {!noCloseBtn && (
-        <CloseButton type="button" onClick={handleClose}>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 8 8"
-            css={{
-              width: '0.5em',
-              height: '0.5em',
-              fill: 'black',
-              position: 'absolute',
-              top: '50%',
-              left: '50%',
-              transform: 'translate(-50%, -50%)',
-            }}
-          >
-            <g fillRule="evenodd" transform="translate(-4 -4)">
-              <path
-                fillOpacity=".5"
-                d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
-              />
-            </g>
-          </svg>
-        </CloseButton>
-      )}
     </AlertWrapper>
   );
 };

--- a/packages/flame/src/Alert/Alert.tsx
+++ b/packages/flame/src/Alert/Alert.tsx
@@ -89,7 +89,7 @@ const Alert: React.FunctionComponent<AlertProps & SpaceProps> = ({
 
   return (
     <AlertWrapper type={type} {...restProps}>
-      <Flex flex="1" alignItems="flex-start" mt={`-${borderTopHeight}px`}>
+      <Flex flex="1" alignItems="flex-start" mt={`-${borderTopHeight}`}>
         {icon && (
           <Box lineHeight={4} pr={2}>
             {icon}

--- a/packages/flame/src/Alert/Alert.tsx
+++ b/packages/flame/src/Alert/Alert.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styled from '@emotion/styled';
 import { transparentize } from 'polished';
-import { space, variant, SpaceProps } from 'styled-system';
+import { space, variant, SpaceProps, layout, LayoutProps } from 'styled-system';
 import { themeGet } from '@styled-system/theme-get';
 import { Flex, Box } from '../Core';
 import { Text } from '../Text';
@@ -28,22 +28,26 @@ AlertWrapper.defaultProps = {
   type: 'info',
 };
 
-const CloseButton = styled('button')`
+const CloseButton = styled('button')<LayoutProps>`
   font-size: ${themeGet('fontSizes.text')};
   color: ${themeGet('colors.textHeading')};
   background-color: ${props => transparentize(0.9, themeGet('colors.textHeading', '#000')(props))};
   border-radius: 50%;
   border: none;
   cursor: pointer;
-  width: 1em;
-  height: 1em;
   padding: 0;
   position: relative;
+  ${layout}
 
   &:focus {
     outline: none;
   }
 `;
+
+CloseButton.defaultProps = {
+  width: ['18px', '16px'],
+  height: ['18px', '16px'],
+};
 
 CloseButton.displayName = 'CloseButton';
 
@@ -90,11 +94,19 @@ const Alert: React.FunctionComponent<AlertProps & SpaceProps> = ({
         )}
         <Box flex="1">
           {title && (
-            <Text color="textHeading" fontWeight="bold" fontSize="text" mt={0} mr={0} mb={1} ml={0}>
+            <Text
+              color="textHeading"
+              fontWeight="bold"
+              fontSize={['text-l', 'text']}
+              mt={0}
+              mr={0}
+              mb={1}
+              ml={0}
+            >
               {title}
             </Text>
           )}
-          <Box fontSize="text-s">{children}</Box>
+          <Box fontSize={['text', 'text-s']}>{children}</Box>
         </Box>
       </Flex>
       {!noCloseBtn && (
@@ -107,10 +119,9 @@ const Alert: React.FunctionComponent<AlertProps & SpaceProps> = ({
               height: '0.5em',
               fill: 'black',
               position: 'absolute',
-              top: '0.25em',
-              left: '0.25em',
-              right: '0',
-              bottom: '0',
+              top: '50%',
+              left: '50%',
+              transform: 'translate(-50%, -50%)',
             }}
           >
             <g fillRule="evenodd" transform="translate(-4 -4)">

--- a/packages/flame/src/Alert/Alert.tsx
+++ b/packages/flame/src/Alert/Alert.tsx
@@ -6,6 +6,8 @@ import { themeGet } from '@styled-system/theme-get';
 import { Flex, Box } from '../Core';
 import { Text } from '../Text';
 
+const borderTopHeight = '4px';
+
 const alertStyles = variant({
   key: 'alertVariants',
   prop: 'type',
@@ -17,7 +19,7 @@ const AlertWrapper = styled('div')<SpaceProps & { type: string }>`
   align-items: flex-start;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.06), 0 3px 6px 0 rgba(0, 0, 0, 0.03),
     0 1px 2px 0 rgba(0, 0, 0, 0.1);
-  border-top: 4px solid;
+  border-top: ${borderTopHeight} solid;
   border-radius: ${themeGet('radii.radius-2')};
   ${space}
   ${alertStyles}
@@ -29,7 +31,7 @@ AlertWrapper.defaultProps = {
   py: [3, 2],
 };
 
-const CloseButton = styled('button')<LayoutProps & SpaceProps>`
+const CloseButton = styled('button')<LayoutProps>`
   font-size: ${themeGet('fontSizes.text')};
   color: ${themeGet('colors.textHeading')};
   background-color: ${props => transparentize(0.9, themeGet('colors.textHeading', '#000')(props))};
@@ -87,7 +89,7 @@ const Alert: React.FunctionComponent<AlertProps & SpaceProps> = ({
 
   return (
     <AlertWrapper type={type} {...restProps}>
-      <Flex flex="1" alignItems="flex-start">
+      <Flex flex="1" alignItems="flex-start" mt={`-${borderTopHeight}px`}>
         {icon && (
           <Box lineHeight={4} pr={2}>
             {icon}

--- a/packages/flame/src/Alert/Alert.tsx
+++ b/packages/flame/src/Alert/Alert.tsx
@@ -101,7 +101,7 @@ const Alert: React.FunctionComponent<AlertProps & SpaceProps> = ({
               fontSize={['text-l', 'text']}
               mt={0}
               mr={0}
-              mb={1}
+              mb={0}
               ml={0}
             >
               {title}

--- a/packages/flame/src/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/packages/flame/src/Alert/__snapshots__/Alert.test.tsx.snap
@@ -43,19 +43,31 @@ exports[`Alert Removes close button 1`] = `
 }
 
 .emotion-2 {
-  font-size: 0.875rem;
+  font-size: 1rem;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-2 {
+    font-size: 0.875rem;
+  }
 }
 
 .emotion-0 {
   margin: 0;
   color: #0c0d0d;
   font-weight: 700;
-  font-size: 1rem;
+  font-size: 1.125rem;
   margin-top: 0;
   margin-right: 0;
   margin-bottom: 0.375rem;
   margin-left: 0;
   font-weight: 700;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    font-size: 1rem;
+  }
 }
 
 <div
@@ -71,14 +83,24 @@ exports[`Alert Removes close button 1`] = `
       <p
         className="emotion-0 emotion-1"
         color="textHeading"
-        fontSize="text"
+        fontSize={
+          Array [
+            "text-l",
+            "text",
+          ]
+        }
         fontWeight="bold"
       >
         My Title
       </p>
       <div
         className="emotion-2 emotion-3"
-        fontSize="text-s"
+        fontSize={
+          Array [
+            "text",
+            "text-s",
+          ]
+        }
       >
         Hello World
       </div>
@@ -130,7 +152,13 @@ exports[`Alert renders a number 1`] = `
 }
 
 .emotion-0 {
-  font-size: 0.875rem;
+  font-size: 1rem;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    font-size: 0.875rem;
+  }
 }
 
 .emotion-7 {
@@ -140,10 +168,17 @@ exports[`Alert renders a number 1`] = `
   border-radius: 50%;
   border: none;
   cursor: pointer;
-  width: 1em;
-  height: 1em;
   padding: 0;
   position: relative;
+  width: 18px;
+  height: 18px;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-7 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-7:focus {
@@ -155,10 +190,11 @@ exports[`Alert renders a number 1`] = `
   height: 0.5em;
   fill: black;
   position: absolute;
-  top: 0.25em;
-  left: 0.25em;
-  right: 0;
-  bottom: 0;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
 }
 
 <div
@@ -173,7 +209,12 @@ exports[`Alert renders a number 1`] = `
     >
       <div
         className="emotion-0 emotion-1"
-        fontSize="text-s"
+        fontSize={
+          Array [
+            "text",
+            "text-s",
+          ]
+        }
       >
         300
       </div>
@@ -181,8 +222,20 @@ exports[`Alert renders a number 1`] = `
   </div>
   <button
     className="emotion-7 emotion-8"
+    height={
+      Array [
+        "18px",
+        "16px",
+      ]
+    }
     onClick={[Function]}
     type="button"
+    width={
+      Array [
+        "18px",
+        "16px",
+      ]
+    }
   >
     <svg
       className="emotion-6"
@@ -246,7 +299,13 @@ exports[`Alert renders correctly 1`] = `
 }
 
 .emotion-0 {
-  font-size: 0.875rem;
+  font-size: 1rem;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    font-size: 0.875rem;
+  }
 }
 
 .emotion-7 {
@@ -256,10 +315,17 @@ exports[`Alert renders correctly 1`] = `
   border-radius: 50%;
   border: none;
   cursor: pointer;
-  width: 1em;
-  height: 1em;
   padding: 0;
   position: relative;
+  width: 18px;
+  height: 18px;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-7 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-7:focus {
@@ -271,10 +337,11 @@ exports[`Alert renders correctly 1`] = `
   height: 0.5em;
   fill: black;
   position: absolute;
-  top: 0.25em;
-  left: 0.25em;
-  right: 0;
-  bottom: 0;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
 }
 
 <div
@@ -289,7 +356,12 @@ exports[`Alert renders correctly 1`] = `
     >
       <div
         className="emotion-0 emotion-1"
-        fontSize="text-s"
+        fontSize={
+          Array [
+            "text",
+            "text-s",
+          ]
+        }
       >
         Hello World
       </div>
@@ -297,8 +369,20 @@ exports[`Alert renders correctly 1`] = `
   </div>
   <button
     className="emotion-7 emotion-8"
+    height={
+      Array [
+        "18px",
+        "16px",
+      ]
+    }
     onClick={[Function]}
     type="button"
+    width={
+      Array [
+        "18px",
+        "16px",
+      ]
+    }
   >
     <svg
       className="emotion-6"
@@ -341,7 +425,13 @@ exports[`Alert renders type danger correctly 1`] = `
 }
 
 .emotion-0 {
-  font-size: 0.875rem;
+  font-size: 1rem;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    font-size: 0.875rem;
+  }
 }
 
 .emotion-7 {
@@ -351,10 +441,17 @@ exports[`Alert renders type danger correctly 1`] = `
   border-radius: 50%;
   border: none;
   cursor: pointer;
-  width: 1em;
-  height: 1em;
   padding: 0;
   position: relative;
+  width: 18px;
+  height: 18px;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-7 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-7:focus {
@@ -366,10 +463,11 @@ exports[`Alert renders type danger correctly 1`] = `
   height: 0.5em;
   fill: black;
   position: absolute;
-  top: 0.25em;
-  left: 0.25em;
-  right: 0;
-  bottom: 0;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
 }
 
 .emotion-9 {
@@ -405,7 +503,12 @@ exports[`Alert renders type danger correctly 1`] = `
     >
       <div
         className="emotion-0 emotion-1"
-        fontSize="text-s"
+        fontSize={
+          Array [
+            "text",
+            "text-s",
+          ]
+        }
       >
         Hello World
       </div>
@@ -413,8 +516,20 @@ exports[`Alert renders type danger correctly 1`] = `
   </div>
   <button
     className="emotion-7 emotion-8"
+    height={
+      Array [
+        "18px",
+        "16px",
+      ]
+    }
     onClick={[Function]}
     type="button"
+    width={
+      Array [
+        "18px",
+        "16px",
+      ]
+    }
   >
     <svg
       className="emotion-6"
@@ -478,7 +593,13 @@ exports[`Alert renders type info correctly 1`] = `
 }
 
 .emotion-0 {
-  font-size: 0.875rem;
+  font-size: 1rem;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    font-size: 0.875rem;
+  }
 }
 
 .emotion-7 {
@@ -488,10 +609,17 @@ exports[`Alert renders type info correctly 1`] = `
   border-radius: 50%;
   border: none;
   cursor: pointer;
-  width: 1em;
-  height: 1em;
   padding: 0;
   position: relative;
+  width: 18px;
+  height: 18px;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-7 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-7:focus {
@@ -503,10 +631,11 @@ exports[`Alert renders type info correctly 1`] = `
   height: 0.5em;
   fill: black;
   position: absolute;
-  top: 0.25em;
-  left: 0.25em;
-  right: 0;
-  bottom: 0;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
 }
 
 <div
@@ -521,7 +650,12 @@ exports[`Alert renders type info correctly 1`] = `
     >
       <div
         className="emotion-0 emotion-1"
-        fontSize="text-s"
+        fontSize={
+          Array [
+            "text",
+            "text-s",
+          ]
+        }
       >
         Hello World
       </div>
@@ -529,8 +663,20 @@ exports[`Alert renders type info correctly 1`] = `
   </div>
   <button
     className="emotion-7 emotion-8"
+    height={
+      Array [
+        "18px",
+        "16px",
+      ]
+    }
     onClick={[Function]}
     type="button"
+    width={
+      Array [
+        "18px",
+        "16px",
+      ]
+    }
   >
     <svg
       className="emotion-6"
@@ -573,7 +719,13 @@ exports[`Alert renders type success correctly 1`] = `
 }
 
 .emotion-0 {
-  font-size: 0.875rem;
+  font-size: 1rem;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    font-size: 0.875rem;
+  }
 }
 
 .emotion-7 {
@@ -583,10 +735,17 @@ exports[`Alert renders type success correctly 1`] = `
   border-radius: 50%;
   border: none;
   cursor: pointer;
-  width: 1em;
-  height: 1em;
   padding: 0;
   position: relative;
+  width: 18px;
+  height: 18px;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-7 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-7:focus {
@@ -598,10 +757,11 @@ exports[`Alert renders type success correctly 1`] = `
   height: 0.5em;
   fill: black;
   position: absolute;
-  top: 0.25em;
-  left: 0.25em;
-  right: 0;
-  bottom: 0;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
 }
 
 .emotion-9 {
@@ -637,7 +797,12 @@ exports[`Alert renders type success correctly 1`] = `
     >
       <div
         className="emotion-0 emotion-1"
-        fontSize="text-s"
+        fontSize={
+          Array [
+            "text",
+            "text-s",
+          ]
+        }
       >
         Hello World
       </div>
@@ -645,8 +810,20 @@ exports[`Alert renders type success correctly 1`] = `
   </div>
   <button
     className="emotion-7 emotion-8"
+    height={
+      Array [
+        "18px",
+        "16px",
+      ]
+    }
     onClick={[Function]}
     type="button"
+    width={
+      Array [
+        "18px",
+        "16px",
+      ]
+    }
   >
     <svg
       className="emotion-6"
@@ -689,7 +866,13 @@ exports[`Alert renders type warning correctly 1`] = `
 }
 
 .emotion-0 {
-  font-size: 0.875rem;
+  font-size: 1rem;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    font-size: 0.875rem;
+  }
 }
 
 .emotion-7 {
@@ -699,10 +882,17 @@ exports[`Alert renders type warning correctly 1`] = `
   border-radius: 50%;
   border: none;
   cursor: pointer;
-  width: 1em;
-  height: 1em;
   padding: 0;
   position: relative;
+  width: 18px;
+  height: 18px;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-7 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-7:focus {
@@ -714,10 +904,11 @@ exports[`Alert renders type warning correctly 1`] = `
   height: 0.5em;
   fill: black;
   position: absolute;
-  top: 0.25em;
-  left: 0.25em;
-  right: 0;
-  bottom: 0;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
 }
 
 .emotion-9 {
@@ -753,7 +944,12 @@ exports[`Alert renders type warning correctly 1`] = `
     >
       <div
         className="emotion-0 emotion-1"
-        fontSize="text-s"
+        fontSize={
+          Array [
+            "text",
+            "text-s",
+          ]
+        }
       >
         Hello World
       </div>
@@ -761,8 +957,20 @@ exports[`Alert renders type warning correctly 1`] = `
   </div>
   <button
     className="emotion-7 emotion-8"
+    height={
+      Array [
+        "18px",
+        "16px",
+      ]
+    }
     onClick={[Function]}
     type="button"
+    width={
+      Array [
+        "18px",
+        "16px",
+      ]
+    }
   >
     <svg
       className="emotion-6"
@@ -826,7 +1034,13 @@ exports[`Alert renders with a title 1`] = `
 }
 
 .emotion-2 {
-  font-size: 0.875rem;
+  font-size: 1rem;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-2 {
+    font-size: 0.875rem;
+  }
 }
 
 .emotion-9 {
@@ -836,10 +1050,17 @@ exports[`Alert renders with a title 1`] = `
   border-radius: 50%;
   border: none;
   cursor: pointer;
-  width: 1em;
-  height: 1em;
   padding: 0;
   position: relative;
+  width: 18px;
+  height: 18px;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-9 {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .emotion-9:focus {
@@ -851,22 +1072,29 @@ exports[`Alert renders with a title 1`] = `
   height: 0.5em;
   fill: black;
   position: absolute;
-  top: 0.25em;
-  left: 0.25em;
-  right: 0;
-  bottom: 0;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
 }
 
 .emotion-0 {
   margin: 0;
   color: #0c0d0d;
   font-weight: 700;
-  font-size: 1rem;
+  font-size: 1.125rem;
   margin-top: 0;
   margin-right: 0;
   margin-bottom: 0.375rem;
   margin-left: 0;
   font-weight: 700;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    font-size: 1rem;
+  }
 }
 
 <div
@@ -882,14 +1110,24 @@ exports[`Alert renders with a title 1`] = `
       <p
         className="emotion-0 emotion-1"
         color="textHeading"
-        fontSize="text"
+        fontSize={
+          Array [
+            "text-l",
+            "text",
+          ]
+        }
         fontWeight="bold"
       >
         My Title
       </p>
       <div
         className="emotion-2 emotion-3"
-        fontSize="text-s"
+        fontSize={
+          Array [
+            "text",
+            "text-s",
+          ]
+        }
       >
         Hello World
       </div>
@@ -897,8 +1135,20 @@ exports[`Alert renders with a title 1`] = `
   </div>
   <button
     className="emotion-9 emotion-10"
+    height={
+      Array [
+        "18px",
+        "16px",
+      ]
+    }
     onClick={[Function]}
     type="button"
+    width={
+      Array [
+        "18px",
+        "16px",
+      ]
+    }
   >
     <svg
       className="emotion-8"

--- a/packages/flame/src/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/packages/flame/src/Alert/__snapshots__/Alert.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`Alert Removes close button 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-  margin-top: -4pxpx;
+  margin-top: -4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -180,7 +180,7 @@ exports[`Alert renders a number 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-  margin-top: -4pxpx;
+  margin-top: -4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -353,7 +353,7 @@ exports[`Alert renders correctly 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-  margin-top: -4pxpx;
+  margin-top: -4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -495,7 +495,7 @@ exports[`Alert renders type danger correctly 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-  margin-top: -4pxpx;
+  margin-top: -4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -699,7 +699,7 @@ exports[`Alert renders type info correctly 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-  margin-top: -4pxpx;
+  margin-top: -4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -841,7 +841,7 @@ exports[`Alert renders type success correctly 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-  margin-top: -4pxpx;
+  margin-top: -4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1014,7 +1014,7 @@ exports[`Alert renders type warning correctly 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-  margin-top: -4pxpx;
+  margin-top: -4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1218,7 +1218,7 @@ exports[`Alert renders with a title 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-  margin-top: -4pxpx;
+  margin-top: -4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/packages/flame/src/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/packages/flame/src/Alert/__snapshots__/Alert.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`Alert Removes close button 1`] = `
   font-size: 1.125rem;
   margin-top: 0;
   margin-right: 0;
-  margin-bottom: 0.375rem;
+  margin-bottom: 0;
   margin-left: 0;
   font-weight: 700;
 }
@@ -1166,7 +1166,7 @@ exports[`Alert renders with a title 1`] = `
   font-size: 1.125rem;
   margin-top: 0;
   margin-right: 0;
-  margin-bottom: 0.375rem;
+  margin-bottom: 0;
   margin-left: 0;
   font-weight: 700;
 }

--- a/packages/flame/src/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/packages/flame/src/Alert/__snapshots__/Alert.test.tsx.snap
@@ -17,9 +17,19 @@ exports[`Alert Removes close button 1`] = `
   box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
   border-top: 4px solid;
   border-radius: 0.375rem;
-  padding: 0.75rem 1.125rem;
+  padding-left: 1.125rem;
+  padding-right: 1.125rem;
+  padding-top: 1.125rem;
+  padding-bottom: 1.125rem;
   background: #e9fafe;
   border-color: #2875c6;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-8 {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
 }
 
 .emotion-6 {
@@ -126,9 +136,19 @@ exports[`Alert renders a number 1`] = `
   box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
   border-top: 4px solid;
   border-radius: 0.375rem;
-  padding: 0.75rem 1.125rem;
+  padding-left: 1.125rem;
+  padding-right: 1.125rem;
+  padding-top: 1.125rem;
+  padding-bottom: 1.125rem;
   background: #e9fafe;
   border-color: #2875c6;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-9 {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
 }
 
 .emotion-4 {
@@ -273,9 +293,19 @@ exports[`Alert renders correctly 1`] = `
   box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
   border-top: 4px solid;
   border-radius: 0.375rem;
-  padding: 0.75rem 1.125rem;
+  padding-left: 1.125rem;
+  padding-right: 1.125rem;
+  padding-top: 1.125rem;
+  padding-bottom: 1.125rem;
   background: #e9fafe;
   border-color: #2875c6;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-9 {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
 }
 
 .emotion-4 {
@@ -486,9 +516,19 @@ exports[`Alert renders type danger correctly 1`] = `
   box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
   border-top: 4px solid;
   border-radius: 0.375rem;
-  padding: 0.75rem 1.125rem;
+  padding-left: 1.125rem;
+  padding-right: 1.125rem;
+  padding-top: 1.125rem;
+  padding-bottom: 1.125rem;
   background: #fee3e3;
   border-color: #b93435;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-9 {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
 }
 
 <div
@@ -567,9 +607,19 @@ exports[`Alert renders type info correctly 1`] = `
   box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
   border-top: 4px solid;
   border-radius: 0.375rem;
-  padding: 0.75rem 1.125rem;
+  padding-left: 1.125rem;
+  padding-right: 1.125rem;
+  padding-top: 1.125rem;
+  padding-bottom: 1.125rem;
   background: #e9fafe;
   border-color: #2875c6;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-9 {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
 }
 
 .emotion-4 {
@@ -780,9 +830,19 @@ exports[`Alert renders type success correctly 1`] = `
   box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
   border-top: 4px solid;
   border-radius: 0.375rem;
-  padding: 0.75rem 1.125rem;
+  padding-left: 1.125rem;
+  padding-right: 1.125rem;
+  padding-top: 1.125rem;
+  padding-bottom: 1.125rem;
   background: #e0f8e6;
   border-color: #26853f;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-9 {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
 }
 
 <div
@@ -927,9 +987,19 @@ exports[`Alert renders type warning correctly 1`] = `
   box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
   border-top: 4px solid;
   border-radius: 0.375rem;
-  padding: 0.75rem 1.125rem;
+  padding-left: 1.125rem;
+  padding-right: 1.125rem;
+  padding-top: 1.125rem;
+  padding-bottom: 1.125rem;
   background: #fdebd0;
   border-color: #e69524;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-9 {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
 }
 
 <div
@@ -1008,9 +1078,19 @@ exports[`Alert renders with a title 1`] = `
   box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
   border-top: 4px solid;
   border-radius: 0.375rem;
-  padding: 0.75rem 1.125rem;
+  padding-left: 1.125rem;
+  padding-right: 1.125rem;
+  padding-top: 1.125rem;
+  padding-bottom: 1.125rem;
   background: #e9fafe;
   border-color: #2875c6;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-11 {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
 }
 
 .emotion-6 {

--- a/packages/flame/src/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/packages/flame/src/Alert/__snapshots__/Alert.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Alert Removes close button 1`] = `
-.emotion-8 {
+.emotion-12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -26,13 +26,13 @@ exports[`Alert Removes close button 1`] = `
 }
 
 @media screen and (min-width:601px) {
-  .emotion-8 {
+  .emotion-12 {
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;
   }
 }
 
-.emotion-6 {
+.emotion-10 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -40,24 +40,36 @@ exports[`Alert Removes close button 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
+  margin-top: -4pxpx;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.emotion-4 {
+.emotion-2 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.emotion-2 {
+.emotion-4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-6 {
   font-size: 1rem;
 }
 
 @media screen and (min-width:601px) {
-  .emotion-2 {
+  .emotion-6 {
     font-size: 0.875rem;
   }
 }
@@ -66,6 +78,7 @@ exports[`Alert Removes close button 1`] = `
   margin: 0;
   color: #0c0d0d;
   font-weight: 700;
+  line-height: 1.5rem;
   font-size: 1.125rem;
   margin-top: 0;
   margin-right: 0;
@@ -81,30 +94,38 @@ exports[`Alert Removes close button 1`] = `
 }
 
 <div
-  className="emotion-8 emotion-9"
+  className="emotion-12 emotion-13"
   type="info"
 >
   <div
-    className="emotion-6 emotion-7"
+    className="emotion-10 emotion-5"
   >
     <div
-      className="emotion-4 emotion-3"
+      className="emotion-2 emotion-3"
     >
-      <p
-        className="emotion-0 emotion-1"
-        color="textHeading"
-        fontSize={
-          Array [
-            "text-l",
-            "text",
-          ]
-        }
-        fontWeight="bold"
-      >
-        My Title
-      </p>
       <div
-        className="emotion-2 emotion-3"
+        className="emotion-4 emotion-5"
+      >
+        <div
+          className="emotion-2 emotion-3"
+        >
+          <p
+            className="emotion-0 emotion-1"
+            color="textHeading"
+            fontSize={
+              Array [
+                "text-l",
+                "text",
+              ]
+            }
+            fontWeight="bold"
+          >
+            My Title
+          </p>
+        </div>
+      </div>
+      <div
+        className="emotion-6 emotion-3"
         fontSize={
           Array [
             "text",
@@ -120,948 +141,6 @@ exports[`Alert Removes close button 1`] = `
 `;
 
 exports[`Alert renders a number 1`] = `
-.emotion-9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
-  border-top: 4px solid;
-  border-radius: 0.375rem;
-  padding-left: 1.125rem;
-  padding-right: 1.125rem;
-  padding-top: 1.125rem;
-  padding-bottom: 1.125rem;
-  background: #e9fafe;
-  border-color: #2875c6;
-}
-
-@media screen and (min-width:601px) {
-  .emotion-9 {
-    padding-top: 0.75rem;
-    padding-bottom: 0.75rem;
-  }
-}
-
-.emotion-4 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.emotion-2 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-0 {
-  font-size: 1rem;
-}
-
-@media screen and (min-width:601px) {
-  .emotion-0 {
-    font-size: 0.875rem;
-  }
-}
-
-.emotion-7 {
-  font-size: 1rem;
-  color: #0c0d0d;
-  background-color: rgba(12,13,13,0.1);
-  border-radius: 50%;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  position: relative;
-  width: 18px;
-  height: 18px;
-}
-
-@media screen and (min-width:601px) {
-  .emotion-7 {
-    width: 16px;
-    height: 16px;
-  }
-}
-
-.emotion-7:focus {
-  outline: none;
-}
-
-.emotion-6 {
-  width: 0.5em;
-  height: 0.5em;
-  fill: black;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-}
-
-<div
-  className="emotion-9 emotion-10"
-  type="info"
->
-  <div
-    className="emotion-4 emotion-5"
-  >
-    <div
-      className="emotion-2 emotion-1"
-    >
-      <div
-        className="emotion-0 emotion-1"
-        fontSize={
-          Array [
-            "text",
-            "text-s",
-          ]
-        }
-      >
-        300
-      </div>
-    </div>
-  </div>
-  <button
-    className="emotion-7 emotion-8"
-    height={
-      Array [
-        "18px",
-        "16px",
-      ]
-    }
-    onClick={[Function]}
-    type="button"
-    width={
-      Array [
-        "18px",
-        "16px",
-      ]
-    }
-  >
-    <svg
-      className="emotion-6"
-      viewBox="0 0 8 8"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g
-        fillRule="evenodd"
-        transform="translate(-4 -4)"
-      >
-        <path
-          d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
-          fillOpacity=".5"
-        />
-      </g>
-    </svg>
-  </button>
-</div>
-`;
-
-exports[`Alert renders correctly 1`] = `
-.emotion-9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
-  border-top: 4px solid;
-  border-radius: 0.375rem;
-  padding-left: 1.125rem;
-  padding-right: 1.125rem;
-  padding-top: 1.125rem;
-  padding-bottom: 1.125rem;
-  background: #e9fafe;
-  border-color: #2875c6;
-}
-
-@media screen and (min-width:601px) {
-  .emotion-9 {
-    padding-top: 0.75rem;
-    padding-bottom: 0.75rem;
-  }
-}
-
-.emotion-4 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.emotion-2 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-0 {
-  font-size: 1rem;
-}
-
-@media screen and (min-width:601px) {
-  .emotion-0 {
-    font-size: 0.875rem;
-  }
-}
-
-.emotion-7 {
-  font-size: 1rem;
-  color: #0c0d0d;
-  background-color: rgba(12,13,13,0.1);
-  border-radius: 50%;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  position: relative;
-  width: 18px;
-  height: 18px;
-}
-
-@media screen and (min-width:601px) {
-  .emotion-7 {
-    width: 16px;
-    height: 16px;
-  }
-}
-
-.emotion-7:focus {
-  outline: none;
-}
-
-.emotion-6 {
-  width: 0.5em;
-  height: 0.5em;
-  fill: black;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-}
-
-<div
-  className="emotion-9 emotion-10"
-  type="info"
->
-  <div
-    className="emotion-4 emotion-5"
-  >
-    <div
-      className="emotion-2 emotion-1"
-    >
-      <div
-        className="emotion-0 emotion-1"
-        fontSize={
-          Array [
-            "text",
-            "text-s",
-          ]
-        }
-      >
-        Hello World
-      </div>
-    </div>
-  </div>
-  <button
-    className="emotion-7 emotion-8"
-    height={
-      Array [
-        "18px",
-        "16px",
-      ]
-    }
-    onClick={[Function]}
-    type="button"
-    width={
-      Array [
-        "18px",
-        "16px",
-      ]
-    }
-  >
-    <svg
-      className="emotion-6"
-      viewBox="0 0 8 8"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g
-        fillRule="evenodd"
-        transform="translate(-4 -4)"
-      >
-        <path
-          d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
-          fillOpacity=".5"
-        />
-      </g>
-    </svg>
-  </button>
-</div>
-`;
-
-exports[`Alert renders type danger correctly 1`] = `
-.emotion-4 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.emotion-2 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-0 {
-  font-size: 1rem;
-}
-
-@media screen and (min-width:601px) {
-  .emotion-0 {
-    font-size: 0.875rem;
-  }
-}
-
-.emotion-7 {
-  font-size: 1rem;
-  color: #0c0d0d;
-  background-color: rgba(12,13,13,0.1);
-  border-radius: 50%;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  position: relative;
-  width: 18px;
-  height: 18px;
-}
-
-@media screen and (min-width:601px) {
-  .emotion-7 {
-    width: 16px;
-    height: 16px;
-  }
-}
-
-.emotion-7:focus {
-  outline: none;
-}
-
-.emotion-6 {
-  width: 0.5em;
-  height: 0.5em;
-  fill: black;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-}
-
-.emotion-9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
-  border-top: 4px solid;
-  border-radius: 0.375rem;
-  padding-left: 1.125rem;
-  padding-right: 1.125rem;
-  padding-top: 1.125rem;
-  padding-bottom: 1.125rem;
-  background: #fee3e3;
-  border-color: #b93435;
-}
-
-@media screen and (min-width:601px) {
-  .emotion-9 {
-    padding-top: 0.75rem;
-    padding-bottom: 0.75rem;
-  }
-}
-
-<div
-  className="emotion-9 emotion-10"
-  type="danger"
->
-  <div
-    className="emotion-4 emotion-5"
-  >
-    <div
-      className="emotion-2 emotion-1"
-    >
-      <div
-        className="emotion-0 emotion-1"
-        fontSize={
-          Array [
-            "text",
-            "text-s",
-          ]
-        }
-      >
-        Hello World
-      </div>
-    </div>
-  </div>
-  <button
-    className="emotion-7 emotion-8"
-    height={
-      Array [
-        "18px",
-        "16px",
-      ]
-    }
-    onClick={[Function]}
-    type="button"
-    width={
-      Array [
-        "18px",
-        "16px",
-      ]
-    }
-  >
-    <svg
-      className="emotion-6"
-      viewBox="0 0 8 8"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g
-        fillRule="evenodd"
-        transform="translate(-4 -4)"
-      >
-        <path
-          d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
-          fillOpacity=".5"
-        />
-      </g>
-    </svg>
-  </button>
-</div>
-`;
-
-exports[`Alert renders type info correctly 1`] = `
-.emotion-9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
-  border-top: 4px solid;
-  border-radius: 0.375rem;
-  padding-left: 1.125rem;
-  padding-right: 1.125rem;
-  padding-top: 1.125rem;
-  padding-bottom: 1.125rem;
-  background: #e9fafe;
-  border-color: #2875c6;
-}
-
-@media screen and (min-width:601px) {
-  .emotion-9 {
-    padding-top: 0.75rem;
-    padding-bottom: 0.75rem;
-  }
-}
-
-.emotion-4 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.emotion-2 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-0 {
-  font-size: 1rem;
-}
-
-@media screen and (min-width:601px) {
-  .emotion-0 {
-    font-size: 0.875rem;
-  }
-}
-
-.emotion-7 {
-  font-size: 1rem;
-  color: #0c0d0d;
-  background-color: rgba(12,13,13,0.1);
-  border-radius: 50%;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  position: relative;
-  width: 18px;
-  height: 18px;
-}
-
-@media screen and (min-width:601px) {
-  .emotion-7 {
-    width: 16px;
-    height: 16px;
-  }
-}
-
-.emotion-7:focus {
-  outline: none;
-}
-
-.emotion-6 {
-  width: 0.5em;
-  height: 0.5em;
-  fill: black;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-}
-
-<div
-  className="emotion-9 emotion-10"
-  type="info"
->
-  <div
-    className="emotion-4 emotion-5"
-  >
-    <div
-      className="emotion-2 emotion-1"
-    >
-      <div
-        className="emotion-0 emotion-1"
-        fontSize={
-          Array [
-            "text",
-            "text-s",
-          ]
-        }
-      >
-        Hello World
-      </div>
-    </div>
-  </div>
-  <button
-    className="emotion-7 emotion-8"
-    height={
-      Array [
-        "18px",
-        "16px",
-      ]
-    }
-    onClick={[Function]}
-    type="button"
-    width={
-      Array [
-        "18px",
-        "16px",
-      ]
-    }
-  >
-    <svg
-      className="emotion-6"
-      viewBox="0 0 8 8"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g
-        fillRule="evenodd"
-        transform="translate(-4 -4)"
-      >
-        <path
-          d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
-          fillOpacity=".5"
-        />
-      </g>
-    </svg>
-  </button>
-</div>
-`;
-
-exports[`Alert renders type success correctly 1`] = `
-.emotion-4 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.emotion-2 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-0 {
-  font-size: 1rem;
-}
-
-@media screen and (min-width:601px) {
-  .emotion-0 {
-    font-size: 0.875rem;
-  }
-}
-
-.emotion-7 {
-  font-size: 1rem;
-  color: #0c0d0d;
-  background-color: rgba(12,13,13,0.1);
-  border-radius: 50%;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  position: relative;
-  width: 18px;
-  height: 18px;
-}
-
-@media screen and (min-width:601px) {
-  .emotion-7 {
-    width: 16px;
-    height: 16px;
-  }
-}
-
-.emotion-7:focus {
-  outline: none;
-}
-
-.emotion-6 {
-  width: 0.5em;
-  height: 0.5em;
-  fill: black;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-}
-
-.emotion-9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
-  border-top: 4px solid;
-  border-radius: 0.375rem;
-  padding-left: 1.125rem;
-  padding-right: 1.125rem;
-  padding-top: 1.125rem;
-  padding-bottom: 1.125rem;
-  background: #e0f8e6;
-  border-color: #26853f;
-}
-
-@media screen and (min-width:601px) {
-  .emotion-9 {
-    padding-top: 0.75rem;
-    padding-bottom: 0.75rem;
-  }
-}
-
-<div
-  className="emotion-9 emotion-10"
-  type="success"
->
-  <div
-    className="emotion-4 emotion-5"
-  >
-    <div
-      className="emotion-2 emotion-1"
-    >
-      <div
-        className="emotion-0 emotion-1"
-        fontSize={
-          Array [
-            "text",
-            "text-s",
-          ]
-        }
-      >
-        Hello World
-      </div>
-    </div>
-  </div>
-  <button
-    className="emotion-7 emotion-8"
-    height={
-      Array [
-        "18px",
-        "16px",
-      ]
-    }
-    onClick={[Function]}
-    type="button"
-    width={
-      Array [
-        "18px",
-        "16px",
-      ]
-    }
-  >
-    <svg
-      className="emotion-6"
-      viewBox="0 0 8 8"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g
-        fillRule="evenodd"
-        transform="translate(-4 -4)"
-      >
-        <path
-          d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
-          fillOpacity=".5"
-        />
-      </g>
-    </svg>
-  </button>
-</div>
-`;
-
-exports[`Alert renders type warning correctly 1`] = `
-.emotion-4 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.emotion-2 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-0 {
-  font-size: 1rem;
-}
-
-@media screen and (min-width:601px) {
-  .emotion-0 {
-    font-size: 0.875rem;
-  }
-}
-
-.emotion-7 {
-  font-size: 1rem;
-  color: #0c0d0d;
-  background-color: rgba(12,13,13,0.1);
-  border-radius: 50%;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  position: relative;
-  width: 18px;
-  height: 18px;
-}
-
-@media screen and (min-width:601px) {
-  .emotion-7 {
-    width: 16px;
-    height: 16px;
-  }
-}
-
-.emotion-7:focus {
-  outline: none;
-}
-
-.emotion-6 {
-  width: 0.5em;
-  height: 0.5em;
-  fill: black;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-}
-
-.emotion-9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
-  border-top: 4px solid;
-  border-radius: 0.375rem;
-  padding-left: 1.125rem;
-  padding-right: 1.125rem;
-  padding-top: 1.125rem;
-  padding-bottom: 1.125rem;
-  background: #fdebd0;
-  border-color: #e69524;
-}
-
-@media screen and (min-width:601px) {
-  .emotion-9 {
-    padding-top: 0.75rem;
-    padding-bottom: 0.75rem;
-  }
-}
-
-<div
-  className="emotion-9 emotion-10"
-  type="warning"
->
-  <div
-    className="emotion-4 emotion-5"
-  >
-    <div
-      className="emotion-2 emotion-1"
-    >
-      <div
-        className="emotion-0 emotion-1"
-        fontSize={
-          Array [
-            "text",
-            "text-s",
-          ]
-        }
-      >
-        Hello World
-      </div>
-    </div>
-  </div>
-  <button
-    className="emotion-7 emotion-8"
-    height={
-      Array [
-        "18px",
-        "16px",
-      ]
-    }
-    onClick={[Function]}
-    type="button"
-    width={
-      Array [
-        "18px",
-        "16px",
-      ]
-    }
-  >
-    <svg
-      className="emotion-6"
-      viewBox="0 0 8 8"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g
-        fillRule="evenodd"
-        transform="translate(-4 -4)"
-      >
-        <path
-          d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
-          fillOpacity=".5"
-        />
-      </g>
-    </svg>
-  </button>
-</div>
-`;
-
-exports[`Alert renders with a title 1`] = `
 .emotion-11 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1093,7 +172,7 @@ exports[`Alert renders with a title 1`] = `
   }
 }
 
-.emotion-6 {
+.emotion-9 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -1101,29 +180,31 @@ exports[`Alert renders with a title 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
+  margin-top: -4pxpx;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.emotion-4 {
+.emotion-7 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.emotion-2 {
-  font-size: 1rem;
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
-@media screen and (min-width:601px) {
-  .emotion-2 {
-    font-size: 0.875rem;
-  }
-}
-
-.emotion-9 {
+.emotion-1 {
   font-size: 1rem;
   color: #0c0d0d;
   background-color: rgba(12,13,13,0.1);
@@ -1137,17 +218,17 @@ exports[`Alert renders with a title 1`] = `
 }
 
 @media screen and (min-width:601px) {
-  .emotion-9 {
+  .emotion-1 {
     width: 16px;
     height: 16px;
   }
 }
 
-.emotion-9:focus {
+.emotion-1:focus {
   outline: none;
 }
 
-.emotion-8 {
+.emotion-0 {
   width: 0.5em;
   height: 0.5em;
   fill: black;
@@ -1159,10 +240,1059 @@ exports[`Alert renders with a title 1`] = `
   transform: translate(-50%,-50%);
 }
 
+.emotion-5 {
+  font-size: 1rem;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-5 {
+    font-size: 0.875rem;
+  }
+}
+
+<div
+  className="emotion-11 emotion-12"
+  type="info"
+>
+  <div
+    className="emotion-9 emotion-4"
+  >
+    <div
+      className="emotion-7 emotion-6"
+    >
+      <div
+        className="emotion-3 emotion-4"
+      >
+        <button
+          className="emotion-1 emotion-2"
+          height={
+            Array [
+              "18px",
+              "16px",
+            ]
+          }
+          onClick={[Function]}
+          type="button"
+          width={
+            Array [
+              "18px",
+              "16px",
+            ]
+          }
+        >
+          <svg
+            className="emotion-0"
+            viewBox="0 0 8 8"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fillRule="evenodd"
+              transform="translate(-4 -4)"
+            >
+              <path
+                d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
+                fillOpacity=".5"
+              />
+            </g>
+          </svg>
+        </button>
+      </div>
+      <div
+        className="emotion-5 emotion-6"
+        fontSize={
+          Array [
+            "text",
+            "text-s",
+          ]
+        }
+      >
+        300
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Alert renders correctly 1`] = `
+.emotion-11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
+  border-top: 4px solid;
+  border-radius: 0.375rem;
+  padding-left: 1.125rem;
+  padding-right: 1.125rem;
+  padding-top: 1.125rem;
+  padding-bottom: 1.125rem;
+  background: #e9fafe;
+  border-color: #2875c6;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-11 {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
+}
+
+.emotion-9 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  margin-top: -4pxpx;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-7 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-1 {
+  font-size: 1rem;
+  color: #0c0d0d;
+  background-color: rgba(12,13,13,0.1);
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  position: relative;
+  width: 18px;
+  height: 18px;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-1 {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.emotion-1:focus {
+  outline: none;
+}
+
+.emotion-0 {
+  width: 0.5em;
+  height: 0.5em;
+  fill: black;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+}
+
+.emotion-5 {
+  font-size: 1rem;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-5 {
+    font-size: 0.875rem;
+  }
+}
+
+<div
+  className="emotion-11 emotion-12"
+  type="info"
+>
+  <div
+    className="emotion-9 emotion-4"
+  >
+    <div
+      className="emotion-7 emotion-6"
+    >
+      <div
+        className="emotion-3 emotion-4"
+      >
+        <button
+          className="emotion-1 emotion-2"
+          height={
+            Array [
+              "18px",
+              "16px",
+            ]
+          }
+          onClick={[Function]}
+          type="button"
+          width={
+            Array [
+              "18px",
+              "16px",
+            ]
+          }
+        >
+          <svg
+            className="emotion-0"
+            viewBox="0 0 8 8"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fillRule="evenodd"
+              transform="translate(-4 -4)"
+            >
+              <path
+                d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
+                fillOpacity=".5"
+              />
+            </g>
+          </svg>
+        </button>
+      </div>
+      <div
+        className="emotion-5 emotion-6"
+        fontSize={
+          Array [
+            "text",
+            "text-s",
+          ]
+        }
+      >
+        Hello World
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Alert renders type danger correctly 1`] = `
+.emotion-9 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  margin-top: -4pxpx;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-7 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-1 {
+  font-size: 1rem;
+  color: #0c0d0d;
+  background-color: rgba(12,13,13,0.1);
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  position: relative;
+  width: 18px;
+  height: 18px;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-1 {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.emotion-1:focus {
+  outline: none;
+}
+
+.emotion-0 {
+  width: 0.5em;
+  height: 0.5em;
+  fill: black;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+}
+
+.emotion-5 {
+  font-size: 1rem;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-5 {
+    font-size: 0.875rem;
+  }
+}
+
+.emotion-11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
+  border-top: 4px solid;
+  border-radius: 0.375rem;
+  padding-left: 1.125rem;
+  padding-right: 1.125rem;
+  padding-top: 1.125rem;
+  padding-bottom: 1.125rem;
+  background: #fee3e3;
+  border-color: #b93435;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-11 {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
+}
+
+<div
+  className="emotion-11 emotion-12"
+  type="danger"
+>
+  <div
+    className="emotion-9 emotion-4"
+  >
+    <div
+      className="emotion-7 emotion-6"
+    >
+      <div
+        className="emotion-3 emotion-4"
+      >
+        <button
+          className="emotion-1 emotion-2"
+          height={
+            Array [
+              "18px",
+              "16px",
+            ]
+          }
+          onClick={[Function]}
+          type="button"
+          width={
+            Array [
+              "18px",
+              "16px",
+            ]
+          }
+        >
+          <svg
+            className="emotion-0"
+            viewBox="0 0 8 8"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fillRule="evenodd"
+              transform="translate(-4 -4)"
+            >
+              <path
+                d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
+                fillOpacity=".5"
+              />
+            </g>
+          </svg>
+        </button>
+      </div>
+      <div
+        className="emotion-5 emotion-6"
+        fontSize={
+          Array [
+            "text",
+            "text-s",
+          ]
+        }
+      >
+        Hello World
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Alert renders type info correctly 1`] = `
+.emotion-11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
+  border-top: 4px solid;
+  border-radius: 0.375rem;
+  padding-left: 1.125rem;
+  padding-right: 1.125rem;
+  padding-top: 1.125rem;
+  padding-bottom: 1.125rem;
+  background: #e9fafe;
+  border-color: #2875c6;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-11 {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
+}
+
+.emotion-9 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  margin-top: -4pxpx;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-7 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-1 {
+  font-size: 1rem;
+  color: #0c0d0d;
+  background-color: rgba(12,13,13,0.1);
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  position: relative;
+  width: 18px;
+  height: 18px;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-1 {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.emotion-1:focus {
+  outline: none;
+}
+
+.emotion-0 {
+  width: 0.5em;
+  height: 0.5em;
+  fill: black;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+}
+
+.emotion-5 {
+  font-size: 1rem;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-5 {
+    font-size: 0.875rem;
+  }
+}
+
+<div
+  className="emotion-11 emotion-12"
+  type="info"
+>
+  <div
+    className="emotion-9 emotion-4"
+  >
+    <div
+      className="emotion-7 emotion-6"
+    >
+      <div
+        className="emotion-3 emotion-4"
+      >
+        <button
+          className="emotion-1 emotion-2"
+          height={
+            Array [
+              "18px",
+              "16px",
+            ]
+          }
+          onClick={[Function]}
+          type="button"
+          width={
+            Array [
+              "18px",
+              "16px",
+            ]
+          }
+        >
+          <svg
+            className="emotion-0"
+            viewBox="0 0 8 8"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fillRule="evenodd"
+              transform="translate(-4 -4)"
+            >
+              <path
+                d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
+                fillOpacity=".5"
+              />
+            </g>
+          </svg>
+        </button>
+      </div>
+      <div
+        className="emotion-5 emotion-6"
+        fontSize={
+          Array [
+            "text",
+            "text-s",
+          ]
+        }
+      >
+        Hello World
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Alert renders type success correctly 1`] = `
+.emotion-9 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  margin-top: -4pxpx;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-7 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-1 {
+  font-size: 1rem;
+  color: #0c0d0d;
+  background-color: rgba(12,13,13,0.1);
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  position: relative;
+  width: 18px;
+  height: 18px;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-1 {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.emotion-1:focus {
+  outline: none;
+}
+
+.emotion-0 {
+  width: 0.5em;
+  height: 0.5em;
+  fill: black;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+}
+
+.emotion-5 {
+  font-size: 1rem;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-5 {
+    font-size: 0.875rem;
+  }
+}
+
+.emotion-11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
+  border-top: 4px solid;
+  border-radius: 0.375rem;
+  padding-left: 1.125rem;
+  padding-right: 1.125rem;
+  padding-top: 1.125rem;
+  padding-bottom: 1.125rem;
+  background: #e0f8e6;
+  border-color: #26853f;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-11 {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
+}
+
+<div
+  className="emotion-11 emotion-12"
+  type="success"
+>
+  <div
+    className="emotion-9 emotion-4"
+  >
+    <div
+      className="emotion-7 emotion-6"
+    >
+      <div
+        className="emotion-3 emotion-4"
+      >
+        <button
+          className="emotion-1 emotion-2"
+          height={
+            Array [
+              "18px",
+              "16px",
+            ]
+          }
+          onClick={[Function]}
+          type="button"
+          width={
+            Array [
+              "18px",
+              "16px",
+            ]
+          }
+        >
+          <svg
+            className="emotion-0"
+            viewBox="0 0 8 8"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fillRule="evenodd"
+              transform="translate(-4 -4)"
+            >
+              <path
+                d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
+                fillOpacity=".5"
+              />
+            </g>
+          </svg>
+        </button>
+      </div>
+      <div
+        className="emotion-5 emotion-6"
+        fontSize={
+          Array [
+            "text",
+            "text-s",
+          ]
+        }
+      >
+        Hello World
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Alert renders type warning correctly 1`] = `
+.emotion-9 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  margin-top: -4pxpx;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-7 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-1 {
+  font-size: 1rem;
+  color: #0c0d0d;
+  background-color: rgba(12,13,13,0.1);
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  position: relative;
+  width: 18px;
+  height: 18px;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-1 {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.emotion-1:focus {
+  outline: none;
+}
+
+.emotion-0 {
+  width: 0.5em;
+  height: 0.5em;
+  fill: black;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+}
+
+.emotion-5 {
+  font-size: 1rem;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-5 {
+    font-size: 0.875rem;
+  }
+}
+
+.emotion-11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
+  border-top: 4px solid;
+  border-radius: 0.375rem;
+  padding-left: 1.125rem;
+  padding-right: 1.125rem;
+  padding-top: 1.125rem;
+  padding-bottom: 1.125rem;
+  background: #fdebd0;
+  border-color: #e69524;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-11 {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
+}
+
+<div
+  className="emotion-11 emotion-12"
+  type="warning"
+>
+  <div
+    className="emotion-9 emotion-4"
+  >
+    <div
+      className="emotion-7 emotion-6"
+    >
+      <div
+        className="emotion-3 emotion-4"
+      >
+        <button
+          className="emotion-1 emotion-2"
+          height={
+            Array [
+              "18px",
+              "16px",
+            ]
+          }
+          onClick={[Function]}
+          type="button"
+          width={
+            Array [
+              "18px",
+              "16px",
+            ]
+          }
+        >
+          <svg
+            className="emotion-0"
+            viewBox="0 0 8 8"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fillRule="evenodd"
+              transform="translate(-4 -4)"
+            >
+              <path
+                d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
+                fillOpacity=".5"
+              />
+            </g>
+          </svg>
+        </button>
+      </div>
+      <div
+        className="emotion-5 emotion-6"
+        fontSize={
+          Array [
+            "text",
+            "text-s",
+          ]
+        }
+      >
+        Hello World
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Alert renders with a title 1`] = `
+.emotion-15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.06),0 3px 6px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.1);
+  border-top: 4px solid;
+  border-radius: 0.375rem;
+  padding-left: 1.125rem;
+  padding-right: 1.125rem;
+  padding-top: 1.125rem;
+  padding-bottom: 1.125rem;
+  background: #e9fafe;
+  border-color: #2875c6;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-15 {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
+}
+
+.emotion-13 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  margin-top: -4pxpx;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-2 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-5 {
+  font-size: 1rem;
+  color: #0c0d0d;
+  background-color: rgba(12,13,13,0.1);
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  position: relative;
+  width: 18px;
+  height: 18px;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-5 {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.emotion-5:focus {
+  outline: none;
+}
+
+.emotion-4 {
+  width: 0.5em;
+  height: 0.5em;
+  fill: black;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+}
+
+.emotion-9 {
+  font-size: 1rem;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-9 {
+    font-size: 0.875rem;
+  }
+}
+
 .emotion-0 {
   margin: 0;
   color: #0c0d0d;
   font-weight: 700;
+  line-height: 1.5rem;
   font-size: 1.125rem;
   margin-top: 0;
   margin-right: 0;
@@ -1178,30 +1308,71 @@ exports[`Alert renders with a title 1`] = `
 }
 
 <div
-  className="emotion-11 emotion-12"
+  className="emotion-15 emotion-16"
   type="info"
 >
   <div
-    className="emotion-6 emotion-7"
+    className="emotion-13 emotion-8"
   >
     <div
-      className="emotion-4 emotion-3"
+      className="emotion-2 emotion-3"
     >
-      <p
-        className="emotion-0 emotion-1"
-        color="textHeading"
-        fontSize={
-          Array [
-            "text-l",
-            "text",
-          ]
-        }
-        fontWeight="bold"
-      >
-        My Title
-      </p>
       <div
-        className="emotion-2 emotion-3"
+        className="emotion-7 emotion-8"
+      >
+        <div
+          className="emotion-2 emotion-3"
+        >
+          <p
+            className="emotion-0 emotion-1"
+            color="textHeading"
+            fontSize={
+              Array [
+                "text-l",
+                "text",
+              ]
+            }
+            fontWeight="bold"
+          >
+            My Title
+          </p>
+        </div>
+        <button
+          className="emotion-5 emotion-6"
+          height={
+            Array [
+              "18px",
+              "16px",
+            ]
+          }
+          onClick={[Function]}
+          type="button"
+          width={
+            Array [
+              "18px",
+              "16px",
+            ]
+          }
+        >
+          <svg
+            className="emotion-4"
+            viewBox="0 0 8 8"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fillRule="evenodd"
+              transform="translate(-4 -4)"
+            >
+              <path
+                d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
+                fillOpacity=".5"
+              />
+            </g>
+          </svg>
+        </button>
+      </div>
+      <div
+        className="emotion-9 emotion-3"
         fontSize={
           Array [
             "text",
@@ -1213,38 +1384,5 @@ exports[`Alert renders with a title 1`] = `
       </div>
     </div>
   </div>
-  <button
-    className="emotion-9 emotion-10"
-    height={
-      Array [
-        "18px",
-        "16px",
-      ]
-    }
-    onClick={[Function]}
-    type="button"
-    width={
-      Array [
-        "18px",
-        "16px",
-      ]
-    }
-  >
-    <svg
-      className="emotion-8"
-      viewBox="0 0 8 8"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g
-        fillRule="evenodd"
-        transform="translate(-4 -4)"
-      >
-        <path
-          d="M9.414 8l2.122-2.121a1 1 0 1 0-1.415-1.415L8 6.586 5.879 4.464A1 1 0 0 0 4.464 5.88L6.586 8l-2.122 2.121a1 1 0 0 0 1.415 1.415L8 9.414l2.121 2.122a1 1 0 0 0 1.415-1.415L9.414 8z"
-          fillOpacity=".5"
-        />
-      </g>
-    </svg>
-  </button>
 </div>
 `;

--- a/packages/flame/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/flame/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -125,9 +125,9 @@ exports[`Autocomplete renders as disabled 1`] = `
 }
 
 .emotion-3 {
+  vertical-align: text-bottom;
   width: 1rem;
   height: 1rem;
-  vertical-align: text-bottom;
 }
 
 <div
@@ -229,13 +229,9 @@ exports[`Autocomplete renders as disabled 1`] = `
         <svg
           className="cr-autocomplete__dropdownIndicator cr-icon emotion-3 emotion-4"
           fill="#848a8a"
-          style={
-            Object {
-              "height": "1rem",
-              "width": "1rem",
-            }
-          }
+          height="1rem"
           viewBox="0 0 16 16"
+          width="1rem"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -379,9 +375,9 @@ exports[`Autocomplete renders correctly 1`] = `
 }
 
 .emotion-3 {
+  vertical-align: text-bottom;
   width: 1rem;
   height: 1rem;
-  vertical-align: text-bottom;
 }
 
 <div
@@ -483,13 +479,9 @@ exports[`Autocomplete renders correctly 1`] = `
         <svg
           className="cr-autocomplete__dropdownIndicator cr-icon emotion-3 emotion-4"
           fill="#848a8a"
-          style={
-            Object {
-              "height": "1rem",
-              "width": "1rem",
-            }
-          }
+          height="1rem"
           viewBox="0 0 16 16"
+          width="1rem"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -647,15 +639,15 @@ exports[`Autocomplete renders in loading mode 1`] = `
 }
 
 .emotion-6 {
+  vertical-align: text-bottom;
   width: 1rem;
   height: 1rem;
-  vertical-align: text-bottom;
 }
 
 .emotion-4 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 1.125rem;
+  height: 1.125rem;
   -webkit-animation: animation-0 1s infinite cubic-bezier(0.35,0.3,0.3,0.35);
   animation: animation-0 1s infinite cubic-bezier(0.35,0.3,0.3,0.35);
 }
@@ -741,13 +733,9 @@ exports[`Autocomplete renders in loading mode 1`] = `
       <svg
         className="emotion-3 cr-icon emotion-4 emotion-5"
         fill="#abb3b3"
-        style={
-          Object {
-            "height": "1.125rem",
-            "width": "1.125rem",
-          }
-        }
+        height="1.125rem"
         viewBox="0 0 16 16"
+        width="1.125rem"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -782,13 +770,9 @@ exports[`Autocomplete renders in loading mode 1`] = `
         <svg
           className="cr-autocomplete__dropdownIndicator cr-icon emotion-6 emotion-5"
           fill="#848a8a"
-          style={
-            Object {
-              "height": "1rem",
-              "width": "1rem",
-            }
-          }
+          height="1rem"
           viewBox="0 0 16 16"
+          width="1rem"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -919,10 +903,16 @@ exports[`Autocomplete renders with an initial value 1`] = `
   fill: #b93435;
 }
 
-.emotion-3 {
+.emotion-5 {
+  vertical-align: text-bottom;
   width: 1rem;
   height: 1rem;
+}
+
+.emotion-3 {
   vertical-align: text-bottom;
+  width: 0.625rem;
+  height: 0.625rem;
 }
 
 .emotion-0 {
@@ -1040,13 +1030,9 @@ exports[`Autocomplete renders with an initial value 1`] = `
         <svg
           className="cr-autocomplete__clearIndicator cr-icon emotion-3 emotion-4"
           fill="hsl(0, 0%, 80%)"
-          style={
-            Object {
-              "height": "0.625rem",
-              "width": "0.625rem",
-            }
-          }
+          height="0.625rem"
           viewBox="0 0 16 16"
+          width="0.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -1074,15 +1060,11 @@ exports[`Autocomplete renders with an initial value 1`] = `
         }
       >
         <svg
-          className="cr-autocomplete__dropdownIndicator cr-icon emotion-3 emotion-4"
+          className="cr-autocomplete__dropdownIndicator cr-icon emotion-5 emotion-4"
           fill="#848a8a"
-          style={
-            Object {
-              "height": "1rem",
-              "width": "1rem",
-            }
-          }
+          height="1rem"
           viewBox="0 0 16 16"
+          width="1rem"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/packages/flame/src/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/flame/src/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -68,9 +68,9 @@ exports[`<Checkbox /> Snapshots when all props and label/description with html s
 }
 
 .emotion-3 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 0.65rem;
+  height: 0.65rem;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -100,13 +100,9 @@ exports[`<Checkbox /> Snapshots when all props and label/description with html s
     >
       <svg
         className="emotion-2 cr-icon emotion-3 emotion-4"
-        style={
-          Object {
-            "height": "0.65rem",
-            "width": "0.65rem",
-          }
-        }
+        height="0.65rem"
         viewBox="0 0 16 16"
+        width="0.65rem"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -193,9 +189,9 @@ exports[`<Checkbox /> Snapshots when all props should render correctly 1`] = `
 }
 
 .emotion-3 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 0.65rem;
+  height: 0.65rem;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -250,13 +246,9 @@ exports[`<Checkbox /> Snapshots when all props should render correctly 1`] = `
     >
       <svg
         className="emotion-2 cr-icon emotion-3 emotion-4"
-        style={
-          Object {
-            "height": "0.65rem",
-            "width": "0.65rem",
-          }
-        }
+        height="0.65rem"
         viewBox="0 0 16 16"
+        width="0.65rem"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -356,9 +348,9 @@ exports[`<Checkbox /> Snapshots when checked should render correctly 1`] = `
 }
 
 .emotion-3 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 0.65rem;
+  height: 0.65rem;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -388,13 +380,9 @@ exports[`<Checkbox /> Snapshots when checked should render correctly 1`] = `
     >
       <svg
         className="emotion-2 cr-icon emotion-3 emotion-4"
-        style={
-          Object {
-            "height": "0.65rem",
-            "width": "0.65rem",
-          }
-        }
+        height="0.65rem"
         viewBox="0 0 16 16"
+        width="0.65rem"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -475,9 +463,9 @@ exports[`<Checkbox /> Snapshots when disabled should render correctly 1`] = `
 }
 
 .emotion-3 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 0.65rem;
+  height: 0.65rem;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -506,13 +494,9 @@ exports[`<Checkbox /> Snapshots when disabled should render correctly 1`] = `
     >
       <svg
         className="emotion-2 cr-icon emotion-3 emotion-4"
-        style={
-          Object {
-            "height": "0.65rem",
-            "width": "0.65rem",
-          }
-        }
+        height="0.65rem"
         viewBox="0 0 16 16"
+        width="0.65rem"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -593,9 +577,9 @@ exports[`<Checkbox /> Snapshots when empty props should render correctly 1`] = `
 }
 
 .emotion-3 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 0.65rem;
+  height: 0.65rem;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -623,13 +607,9 @@ exports[`<Checkbox /> Snapshots when empty props should render correctly 1`] = `
     >
       <svg
         className="emotion-2 cr-icon emotion-3 emotion-4"
-        style={
-          Object {
-            "height": "0.65rem",
-            "width": "0.65rem",
-          }
-        }
+        height="0.65rem"
         viewBox="0 0 16 16"
+        width="0.65rem"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -694,9 +674,9 @@ exports[`<Checkbox /> Snapshots when indeterminate should render correctly 1`] =
 }
 
 .emotion-3 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 0.65rem;
+  height: 0.65rem;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -754,13 +734,9 @@ exports[`<Checkbox /> Snapshots when indeterminate should render correctly 1`] =
     >
       <svg
         className="emotion-2 cr-icon emotion-3 emotion-4"
-        style={
-          Object {
-            "height": "0.65rem",
-            "width": "0.65rem",
-          }
-        }
+        height="0.65rem"
         viewBox="0 0 16 16"
+        width="0.65rem"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -844,9 +820,9 @@ exports[`<Checkbox /> Snapshots when not checked should render correctly 1`] = `
 }
 
 .emotion-3 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 0.65rem;
+  height: 0.65rem;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -875,13 +851,9 @@ exports[`<Checkbox /> Snapshots when not checked should render correctly 1`] = `
     >
       <svg
         className="emotion-2 cr-icon emotion-3 emotion-4"
-        style={
-          Object {
-            "height": "0.65rem",
-            "width": "0.65rem",
-          }
-        }
+        height="0.65rem"
         viewBox="0 0 16 16"
+        width="0.65rem"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path

--- a/packages/flame/src/Icon/__tests__/__snapshots__/Icon.test.tsx.snap
+++ b/packages/flame/src/Icon/__tests__/__snapshots__/Icon.test.tsx.snap
@@ -2,20 +2,33 @@
 
 exports[`Icon renders correctly 1`] = `
 .emotion-0 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 18px;
+  height: 18px;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    width: 1rem;
+    height: 1rem;
+  }
 }
 
 <svg
   className=" cr-icon emotion-0 emotion-1"
-  style={
-    Object {
-      "height": "1rem",
-      "width": "1rem",
-    }
+  height={
+    Array [
+      "18px",
+      "1rem",
+    ]
   }
   viewBox="0 0 16 16"
+  width={
+    Array [
+      "18px",
+      "1rem",
+    ]
+  }
   xmlns="http://www.w3.org/2000/svg"
 >
   <path
@@ -32,20 +45,33 @@ exports[`Icon renders correctly 1`] = `
 
 exports[`Icon renders with baseColor and detailColor 1`] = `
 .emotion-0 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 18px;
+  height: 18px;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    width: 1rem;
+    height: 1rem;
+  }
 }
 
 <svg
   className=" cr-icon emotion-0 emotion-1"
-  style={
-    Object {
-      "height": "1rem",
-      "width": "1rem",
-    }
+  height={
+    Array [
+      "18px",
+      "1rem",
+    ]
   }
   viewBox="0 0 16 16"
+  width={
+    Array [
+      "18px",
+      "1rem",
+    ]
+  }
   xmlns="http://www.w3.org/2000/svg"
 >
   <path
@@ -70,21 +96,34 @@ exports[`Icon renders with baseColor and detailColor 1`] = `
 
 exports[`Icon renders with color 1`] = `
 .emotion-0 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 18px;
+  height: 18px;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-0 {
+    width: 1rem;
+    height: 1rem;
+  }
 }
 
 <svg
   className=" cr-icon emotion-0 emotion-1"
   fill="cr-blue"
-  style={
-    Object {
-      "height": "1rem",
-      "width": "1rem",
-    }
+  height={
+    Array [
+      "18px",
+      "1rem",
+    ]
   }
   viewBox="0 0 16 16"
+  width={
+    Array [
+      "18px",
+      "1rem",
+    ]
+  }
   xmlns="http://www.w3.org/2000/svg"
 >
   <path

--- a/packages/flame/src/Icon/utils/iconFactory.tsx
+++ b/packages/flame/src/Icon/utils/iconFactory.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 import { withTheme } from 'emotion-theming';
 import { themeGet } from '@styled-system/theme-get';
+import { layout, LayoutProps } from 'styled-system';
 
 export type IconProps = {
   /** Name of requested Icon */
@@ -29,7 +30,7 @@ export type IconProps = {
 
 export default function iconFactory(BaseIconComponent: React.FC, displayName = 'FlameIcon') {
   const EnhancedIcon: React.FC<IconProps> = ({
-    size = '1rem',
+    size,
     className,
     color,
     baseColor,
@@ -59,14 +60,17 @@ export default function iconFactory(BaseIconComponent: React.FC, displayName = '
         to set an icons color or fill property.
       */
       className: [className, 'cr-icon'].join(' '),
-      style: { width: iconSize, height: iconSize },
     };
 
-    const StyledIcon = styled(BaseIconComponent)`
-      width: 1rem;
-      height: 1rem;
+    const StyledIcon = styled(BaseIconComponent)<LayoutProps>`
       vertical-align: text-bottom;
+      ${layout};
     `;
+
+    StyledIcon.defaultProps = {
+      width: iconSize || ['18px', '1rem'],
+      height: iconSize || ['18px', '1rem'],
+    };
 
     return <StyledIcon {...stylingProps} {...restProps} />;
   };

--- a/packages/flame/src/Spinner/__snapshots__/Spinner.test.tsx.snap
+++ b/packages/flame/src/Spinner/__snapshots__/Spinner.test.tsx.snap
@@ -16,23 +16,36 @@ exports[`<Spinner /> Snapshots when color is cr-blue should render correctly 1`]
 }
 
 .emotion-1 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 18px;
+  height: 18px;
   -webkit-animation: animation-0 1s infinite cubic-bezier(0.35,0.3,0.3,0.35);
   animation: animation-0 1s infinite cubic-bezier(0.35,0.3,0.3,0.35);
+}
+
+@media screen and (min-width:601px) {
+  .emotion-1 {
+    width: 1rem;
+    height: 1rem;
+  }
 }
 
 <svg
   className="emotion-0 cr-icon emotion-1 emotion-2"
   fill="#2875c6"
-  style={
-    Object {
-      "height": "1rem",
-      "width": "1rem",
-    }
+  height={
+    Array [
+      "18px",
+      "1rem",
+    ]
   }
   viewBox="0 0 16 16"
+  width={
+    Array [
+      "18px",
+      "1rem",
+    ]
+  }
   xmlns="http://www.w3.org/2000/svg"
 >
   <path
@@ -63,22 +76,35 @@ exports[`<Spinner /> Snapshots when empty props should render correctly 1`] = `
 }
 
 .emotion-1 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 18px;
+  height: 18px;
   -webkit-animation: animation-0 1s infinite cubic-bezier(0.35,0.3,0.3,0.35);
   animation: animation-0 1s infinite cubic-bezier(0.35,0.3,0.3,0.35);
 }
 
+@media screen and (min-width:601px) {
+  .emotion-1 {
+    width: 1rem;
+    height: 1rem;
+  }
+}
+
 <svg
   className="emotion-0 cr-icon emotion-1 emotion-2"
-  style={
-    Object {
-      "height": "1rem",
-      "width": "1rem",
-    }
+  height={
+    Array [
+      "18px",
+      "1rem",
+    ]
   }
   viewBox="0 0 16 16"
+  width={
+    Array [
+      "18px",
+      "1rem",
+    ]
+  }
   xmlns="http://www.w3.org/2000/svg"
 >
   <path
@@ -109,22 +135,18 @@ exports[`<Spinner /> Snapshots when size is xlarge should render correctly 1`] =
 }
 
 .emotion-1 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 1.5rem;
+  height: 1.5rem;
   -webkit-animation: animation-0 1s infinite cubic-bezier(0.35,0.3,0.3,0.35);
   animation: animation-0 1s infinite cubic-bezier(0.35,0.3,0.3,0.35);
 }
 
 <svg
   className="emotion-0 cr-icon emotion-1 emotion-2"
-  style={
-    Object {
-      "height": "1.5rem",
-      "width": "1.5rem",
-    }
-  }
+  height="1.5rem"
   viewBox="0 0 16 16"
+  width="1.5rem"
   xmlns="http://www.w3.org/2000/svg"
 >
   <path

--- a/packages/flame/src/Switch/__snapshots__/Switch.test.tsx.snap
+++ b/packages/flame/src/Switch/__snapshots__/Switch.test.tsx.snap
@@ -119,16 +119,16 @@ exports[`<Switch /> when autoFocus should render correctly 1`] = `
 }
 
 .emotion-7 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 0.75rem;
+  height: 0.75rem;
   fill: #fff;
 }
 
 .emotion-10 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 0.75rem;
+  height: 0.75rem;
   fill: #848a8a;
 }
 
@@ -166,13 +166,9 @@ exports[`<Switch /> when autoFocus should render correctly 1`] = `
     >
       <svg
         className="emotion-6 cr-icon emotion-7 emotion-8"
-        style={
-          Object {
-            "height": "0.75rem",
-            "width": "0.75rem",
-          }
-        }
+        height="0.75rem"
         viewBox="0 0 16 16"
+        width="0.75rem"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -182,13 +178,9 @@ exports[`<Switch /> when autoFocus should render correctly 1`] = `
       </svg>
       <svg
         className="emotion-9 cr-icon emotion-10 emotion-8"
-        style={
-          Object {
-            "height": "0.75rem",
-            "width": "0.75rem",
-          }
-        }
+        height="0.75rem"
         viewBox="0 0 16 16"
+        width="0.75rem"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -320,16 +312,16 @@ exports[`<Switch /> when checked should render correctly 1`] = `
 }
 
 .emotion-7 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 0.75rem;
+  height: 0.75rem;
   fill: #fff;
 }
 
 .emotion-10 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 0.75rem;
+  height: 0.75rem;
   fill: #848a8a;
 }
 
@@ -367,13 +359,9 @@ exports[`<Switch /> when checked should render correctly 1`] = `
     >
       <svg
         className="emotion-6 cr-icon emotion-7 emotion-8"
-        style={
-          Object {
-            "height": "0.75rem",
-            "width": "0.75rem",
-          }
-        }
+        height="0.75rem"
         viewBox="0 0 16 16"
+        width="0.75rem"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -383,13 +371,9 @@ exports[`<Switch /> when checked should render correctly 1`] = `
       </svg>
       <svg
         className="emotion-9 cr-icon emotion-10 emotion-8"
-        style={
-          Object {
-            "height": "0.75rem",
-            "width": "0.75rem",
-          }
-        }
+        height="0.75rem"
         viewBox="0 0 16 16"
+        width="0.75rem"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -521,16 +505,16 @@ exports[`<Switch /> when disabled should render correctly 1`] = `
 }
 
 .emotion-7 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 0.75rem;
+  height: 0.75rem;
   fill: #fff;
 }
 
 .emotion-10 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 0.75rem;
+  height: 0.75rem;
   fill: #848a8a;
 }
 
@@ -568,13 +552,9 @@ exports[`<Switch /> when disabled should render correctly 1`] = `
     >
       <svg
         className="emotion-6 cr-icon emotion-7 emotion-8"
-        style={
-          Object {
-            "height": "0.75rem",
-            "width": "0.75rem",
-          }
-        }
+        height="0.75rem"
         viewBox="0 0 16 16"
+        width="0.75rem"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -584,13 +564,9 @@ exports[`<Switch /> when disabled should render correctly 1`] = `
       </svg>
       <svg
         className="emotion-9 cr-icon emotion-10 emotion-8"
-        style={
-          Object {
-            "height": "0.75rem",
-            "width": "0.75rem",
-          }
-        }
+        height="0.75rem"
         viewBox="0 0 16 16"
+        width="0.75rem"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -722,16 +698,16 @@ exports[`<Switch /> when empty props should render correctly 1`] = `
 }
 
 .emotion-7 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 0.75rem;
+  height: 0.75rem;
   fill: #fff;
 }
 
 .emotion-10 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 0.75rem;
+  height: 0.75rem;
   fill: #848a8a;
 }
 
@@ -768,13 +744,9 @@ exports[`<Switch /> when empty props should render correctly 1`] = `
     >
       <svg
         className="emotion-6 cr-icon emotion-7 emotion-8"
-        style={
-          Object {
-            "height": "0.75rem",
-            "width": "0.75rem",
-          }
-        }
+        height="0.75rem"
         viewBox="0 0 16 16"
+        width="0.75rem"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -784,13 +756,9 @@ exports[`<Switch /> when empty props should render correctly 1`] = `
       </svg>
       <svg
         className="emotion-9 cr-icon emotion-10 emotion-8"
-        style={
-          Object {
-            "height": "0.75rem",
-            "width": "0.75rem",
-          }
-        }
+        height="0.75rem"
         viewBox="0 0 16 16"
+        width="0.75rem"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -922,16 +890,16 @@ exports[`<Switch /> when id, name should render correctly 1`] = `
 }
 
 .emotion-7 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 0.75rem;
+  height: 0.75rem;
   fill: #fff;
 }
 
 .emotion-10 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 0.75rem;
+  height: 0.75rem;
   fill: #848a8a;
 }
 
@@ -970,13 +938,9 @@ exports[`<Switch /> when id, name should render correctly 1`] = `
     >
       <svg
         className="emotion-6 cr-icon emotion-7 emotion-8"
-        style={
-          Object {
-            "height": "0.75rem",
-            "width": "0.75rem",
-          }
-        }
+        height="0.75rem"
         viewBox="0 0 16 16"
+        width="0.75rem"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -986,13 +950,9 @@ exports[`<Switch /> when id, name should render correctly 1`] = `
       </svg>
       <svg
         className="emotion-9 cr-icon emotion-10 emotion-8"
-        style={
-          Object {
-            "height": "0.75rem",
-            "width": "0.75rem",
-          }
-        }
+        height="0.75rem"
         viewBox="0 0 16 16"
+        width="0.75rem"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -1124,16 +1084,16 @@ exports[`<Switch /> when passing data-props should render correctly 1`] = `
 }
 
 .emotion-7 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 0.75rem;
+  height: 0.75rem;
   fill: #fff;
 }
 
 .emotion-10 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 0.75rem;
+  height: 0.75rem;
   fill: #848a8a;
 }
 
@@ -1171,13 +1131,9 @@ exports[`<Switch /> when passing data-props should render correctly 1`] = `
     >
       <svg
         className="emotion-6 cr-icon emotion-7 emotion-8"
-        style={
-          Object {
-            "height": "0.75rem",
-            "width": "0.75rem",
-          }
-        }
+        height="0.75rem"
         viewBox="0 0 16 16"
+        width="0.75rem"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -1187,13 +1143,9 @@ exports[`<Switch /> when passing data-props should render correctly 1`] = `
       </svg>
       <svg
         className="emotion-9 cr-icon emotion-10 emotion-8"
-        style={
-          Object {
-            "height": "0.75rem",
-            "width": "0.75rem",
-          }
-        }
+        height="0.75rem"
         viewBox="0 0 16 16"
+        width="0.75rem"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path

--- a/packages/flame/src/Tag/__snapshots__/Tag.test.tsx.snap
+++ b/packages/flame/src/Tag/__snapshots__/Tag.test.tsx.snap
@@ -242,12 +242,19 @@ exports[`<Tag /> Snapshots when dismissible should render correctly 1`] = `
 }
 
 .emotion-3 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 18px;
+  height: 18px;
   margin: 0 0.375rem;
   border-radius: 50%;
   z-index: 1;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-3 {
+    width: 1rem;
+    height: 1rem;
+  }
 }
 
 <div
@@ -269,13 +276,19 @@ exports[`<Tag /> Snapshots when dismissible should render correctly 1`] = `
   >
     <svg
       className="emotion-2 cr-icon emotion-3 emotion-4"
-      style={
-        Object {
-          "height": "1rem",
-          "width": "1rem",
-        }
+      height={
+        Array [
+          "18px",
+          "1rem",
+        ]
       }
       viewBox="0 0 16 16"
+      width={
+        Array [
+          "18px",
+          "1rem",
+        ]
+      }
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -366,12 +379,19 @@ exports[`<Tag /> Snapshots when small should render correctly 1`] = `
 }
 
 .emotion-3 {
-  width: 1rem;
-  height: 1rem;
   vertical-align: text-bottom;
+  width: 18px;
+  height: 18px;
   margin: 0 0.375rem;
   border-radius: 50%;
   z-index: 1;
+}
+
+@media screen and (min-width:601px) {
+  .emotion-3 {
+    width: 1rem;
+    height: 1rem;
+  }
 }
 
 .emotion-0 {
@@ -463,13 +483,19 @@ exports[`<Tag /> Snapshots when small should render correctly 1`] = `
   >
     <svg
       className="emotion-2 cr-icon emotion-3 emotion-4"
-      style={
-        Object {
-          "height": "1rem",
-          "width": "1rem",
-        }
+      height={
+        Array [
+          "18px",
+          "1rem",
+        ]
       }
       viewBox="0 0 16 16"
+      width={
+        Array [
+          "18px",
+          "1rem",
+        ]
+      }
       xmlns="http://www.w3.org/2000/svg"
     >
       <path


### PR DESCRIPTION
## Description

Both will now resize appropriately in their mobile breakpoints. Mostly just adjusting the size of fonts

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [x] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] When approved, I have run [visual regression tests](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#running-visual-regression-tests), got it approved and [posted a link](https://percy.io/Lightspeed/flame)
