### PR TITLE
Add a CodeSandbox starter for new bug issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -27,6 +27,8 @@ What actually happens? Include an error message (in a `<details></details>` tag 
 
 1. 2. 3.
 
+Or provide a [CodeSandbox](https://codesandbox.io/s/lightspeed-flame-components-n0bn2)
+
 ## Specifications
 
 - Affected component(s):

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -27,7 +27,7 @@ What actually happens? Include an error message (in a `<details></details>` tag 
 
 1. 2. 3.
 
-Or provide a [CodeSandbox](https://codesandbox.io/s/lightspeed-flame-components-n0bn2)
+Or fork our [CodeSandbox](https://codesandbox.io/s/lightspeed-flame-components-n0bn2) to provide a working example.
 
 ## Specifications
 


### PR DESCRIPTION
## Description

Provide a Flame starter CodeSandbox, helpful for reproducing/debugging new issues.

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [ ] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [ ] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] When approved, I have run [visual regression tests](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#running-visual-regression-tests), got it approved and [posted a link](https://percy.io/Lightspeed/flame)
