### PR TITLE
Enable GitHub Actions caching dependencies

### DIFF
--- a/.github/workflows/publish-lerna.yml
+++ b/.github/workflows/publish-lerna.yml
@@ -1,28 +1,37 @@
 on:
   push:
     branches:
-    - master
+      - master
 name: Publish lerna
 jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
-    - name: Use Node.js 10.16.0
-      uses: actions/setup-node@v1.1.1
-      with:
-        node-version: 10.16.0
-        registry-url: https://registry.npmjs.org/
-    - name: Install
-      run: yarn install --frozen-lockfile
-    - name: Bootstrap
-      run: yarn bootstrap
-    - name: Publish
-      run: yarn lerna:publish
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      - uses: actions/checkout@v1
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - name: Read .nvmrc
+        run: echo ::set-output name=nvmrc::$(cat .nvmrc)
+        id: nvm
+      - name: Setup node
+        uses: actions/setup-node@v1.1.1
+        with:
+          node-version: '${{ steps.nvm.outputs.nvmrc }}'
+          registry-url: https://registry.npmjs.org/
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/yarn
+          key: ${{ runner.OS }}-yarn-cache-v1-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-cache-v1-
+      - name: Install
+        run: yarn install --frozen-lockfile
+      - name: Bootstrap
+        run: yarn bootstrap
+      - name: Publish
+        run: yarn lerna:publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/publish-mainline.yml
+++ b/.github/workflows/publish-mainline.yml
@@ -1,30 +1,39 @@
 on:
   push:
     branches:
-    - master
+      - master
 name: Publish mainline
 jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
-    - name: Use Node.js 10.16.0
-      uses: actions/setup-node@v1.1.1
-      with:
-        node-version: 10.16.0
-        registry-url: https://registry.npmjs.org/
-    - name: Install
-      run: yarn install --frozen-lockfile
-    - name: Bootstrap
-      run: yarn bootstrap
-    - name: Publish
-      run: |
-        cd packages/flame
-        node ./scripts/check-changed.js && yarn build && npm publish dist --quiet || exit 0
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      - uses: actions/checkout@v1
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - name: Read .nvmrc
+        run: echo ::set-output name=nvmrc::$(cat .nvmrc)
+        id: nvm
+      - name: Setup node
+        uses: actions/setup-node@v1.1.1
+        with:
+          node-version: '${{ steps.nvm.outputs.nvmrc }}'
+          registry-url: https://registry.npmjs.org/
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/yarn
+          key: ${{ runner.OS }}-yarn-cache-v1-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-cache-v1-
+      - name: Install
+        run: yarn install --frozen-lockfile
+      - name: Bootstrap
+        run: yarn bootstrap
+      - name: Publish
+        run: |
+          cd packages/flame
+          node ./scripts/check-changed.js && yarn build && npm publish dist --quiet || exit 0
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Description

Let's speed up GitHub Actions workflows ("Publish mainline" and "Publish lerna") by taking advantage of the newly added [caching dependencies](https://help.github.com/en/github/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows) feature.

<!-- Uncomment below if it closes an opened issue -->
<!-- Closes #XXX -->

## How to test?

- When merged to `master`, "Publish lerna" and "Publish mainline" workflows should first install deps from fresh, then, on subsequent merges, it should use the `yarn` cached version

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [ ] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [ ] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [ ] I have added tests that prove my fix is effective or that my feature works
