### PR TITLE
Properly type InputGroup. Pass onClick callback to dropdown toggle

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -13,6 +13,11 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 - Dropdown menu position can now be further customized. You can simply pass the the appropriate PopperJS placement to the `placement` prop and the menu will be adjusted accordingly ([#37](https://github.com/lightspeed/flame/pull/37))
 
+### Fixed
+
+- Dropdown toggle when clicked will not be overwritten if we override the `onClick` prop
+- InputGroup is now typed properly using the `Flex` props
+
 ## 1.1.0 - 2019-10-25
 
 ### Added

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -15,8 +15,8 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ### Fixed
 
-- Dropdown toggle when clicked will not be overwritten if we override the `onClick` prop
-- InputGroup is now typed properly using the `Flex` props
+- Dropdown toggle when clicked will not be overwritten if we override the `onClick` prop ([#40](https://github.com/lightspeed/flame/pull/40))
+- InputGroup is now typed properly using the `Flex` props ([#40](https://github.com/lightspeed/flame/pull/40))
 
 ## 1.1.0 - 2019-10-25
 

--- a/packages/flame/src/Dropdown/Dropdown.test.tsx
+++ b/packages/flame/src/Dropdown/Dropdown.test.tsx
@@ -46,6 +46,31 @@ describe('<Dropdown />', () => {
     expect(queryByText('Some dropdown content')).not.toBeVisible();
   });
 
+  it('should trigger our custom callback when we click the button', () => {
+    const mockFn = jest.fn();
+    const { queryByText } = customRender(
+      <div>
+        <Dropdown buttonContent="My Dropdown" onClick={mockFn}>
+          Some dropdown content
+        </Dropdown>
+        <div>I am outside the dropdown</div>
+      </div>,
+    );
+
+    expect(queryByText('My Dropdown')).toBeTruthy();
+    expect(queryByText('Some dropdown content')).not.toBeVisible();
+
+    fireEvent.click(queryByText('My Dropdown'));
+    expect(queryByText('Some dropdown content')).toBeVisible();
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(queryByText('I am outside the dropdown'));
+    expect(queryByText('Some dropdown content')).not.toBeVisible();
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
   it('should close when we hit escape', () => {
     const { queryByText, container } = customRender(
       <div>

--- a/packages/flame/src/Dropdown/Dropdown.tsx
+++ b/packages/flame/src/Dropdown/Dropdown.tsx
@@ -108,6 +108,7 @@ const Dropdown: React.FC<Props> = ({
   initiallyOpen = false,
   zIndex = 1,
   children,
+  onClick,
   ...restProps
 }) => {
   const targetRef = React.createRef<HTMLDivElement>();
@@ -144,7 +145,12 @@ const Dropdown: React.FC<Props> = ({
         <Button
           pr={2}
           pl={2}
-          onClick={toggle}
+          onClick={(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+            if (typeof onClick === 'function') {
+              onClick(event);
+            }
+            toggle();
+          }}
           forcedState={isActive ? 'active' : null}
           {...(restProps as any)}
         >

--- a/packages/flame/src/InputGroup/InputGroup.tsx
+++ b/packages/flame/src/InputGroup/InputGroup.tsx
@@ -24,7 +24,7 @@ const InputGroupAddon = styled(Flex)<InputGroupAddonProps>`
   )};
 `;
 
-const InputGroup: React.FC = ({ children, ...restProps }) => {
+const InputGroup: React.FC<FlameFlexProps> = ({ children, ...restProps }) => {
   const nextChildren = React.Children.map(children, (child: any, index) => {
     if (index === 0) {
       return React.cloneElement(child, {


### PR DESCRIPTION
## Description

Passing an onClick handle on the Dropdown would override the toggle function. Now, we will always trigger the toggle, even when an onClick handler is passed.

Additionally, the InputGroup has been typed properly.


## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [x] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [x] I have added tests that prove my fix is effective or that my feature works
