### PR TITLE
Properly type InputGroup. Pass onClick callback to dropdown toggle

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -18,6 +18,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 - Dropdown toggle when clicked will not be overwritten if we override the `onClick` prop ([#41](https://github.com/lightspeed/flame/pull/41))
 - InputGroup is now typed properly using the `Flex` props ([#41](https://github.com/lightspeed/flame/pull/41))
 - Made Input status and message optional in typings ([#41](https://github.com/lightspeed/flame/pull/41))
+- Pass back in space props to the InputGroupAddon ([#41](https://github.com/lightspeed/flame/pull/41))
 
 ## 1.1.0 - 2019-10-25
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -17,6 +17,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 - Dropdown toggle when clicked will not be overwritten if we override the `onClick` prop ([#41](https://github.com/lightspeed/flame/pull/41))
 - InputGroup is now typed properly using the `Flex` props ([#41](https://github.com/lightspeed/flame/pull/41))
+- Made Input status and message optional in typings ([#41](https://github.com/lightspeed/flame/pull/41))
 
 ## 1.1.0 - 2019-10-25
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -15,8 +15,8 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ### Fixed
 
-- Dropdown toggle when clicked will not be overwritten if we override the `onClick` prop ([#40](https://github.com/lightspeed/flame/pull/40))
-- InputGroup is now typed properly using the `Flex` props ([#40](https://github.com/lightspeed/flame/pull/40))
+- Dropdown toggle when clicked will not be overwritten if we override the `onClick` prop ([#41](https://github.com/lightspeed/flame/pull/41))
+- InputGroup is now typed properly using the `Flex` props ([#41](https://github.com/lightspeed/flame/pull/41))
 
 ## 1.1.0 - 2019-10-25
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -13,6 +13,11 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 - Dropdown menu position can now be further customized. You can simply pass the the appropriate PopperJS placement to the `placement` prop and the menu will be adjusted accordingly ([#37](https://github.com/lightspeed/flame/pull/37))
 
+### Fixed
+
+- Dropdown toggle when clicked will not be overwritten if we override the `onClick` prop ([#40](https://github.com/lightspeed/flame/pull/40))
+- InputGroup is now typed properly using the `Flex` props ([#40](https://github.com/lightspeed/flame/pull/40))
+
 ## 1.1.0 - 2019-10-25
 
 ### Added

--- a/packages/flame/src/Dropdown/Dropdown.test.tsx
+++ b/packages/flame/src/Dropdown/Dropdown.test.tsx
@@ -46,6 +46,37 @@ describe('<Dropdown />', () => {
     expect(queryByText('Some dropdown content')).not.toBeVisible();
   });
 
+  it('should trigger our custom callback when we click the button', () => {
+    const mockFn = jest.fn();
+    const { queryByText } = customRender(
+      <div>
+        <Dropdown
+          buttonContent="My Dropdown"
+          onClick={toggle => {
+            mockFn();
+            toggle();
+          }}
+        >
+          Some dropdown content
+        </Dropdown>
+        <div>I am outside the dropdown</div>
+      </div>,
+    );
+
+    expect(queryByText('My Dropdown')).toBeTruthy();
+    expect(queryByText('Some dropdown content')).not.toBeVisible();
+
+    fireEvent.click(queryByText('My Dropdown'));
+    expect(queryByText('Some dropdown content')).toBeVisible();
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(queryByText('I am outside the dropdown'));
+    expect(queryByText('Some dropdown content')).not.toBeVisible();
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
   it('should close when we hit escape', () => {
     const { queryByText, container } = customRender(
       <div>

--- a/packages/flame/src/Dropdown/Dropdown.tsx
+++ b/packages/flame/src/Dropdown/Dropdown.tsx
@@ -16,10 +16,11 @@ import { useOnClickOutside } from '../hooks/useOnClickOutside';
 
 type Placement = 'start' | 'center' | 'end' | PopperPlacement;
 
-interface Props extends Merge<PopoverContainerProps, ButtonProps> {
+interface Props extends Merge<PopoverContainerProps, Omit<ButtonProps, 'onClick'>> {
   buttonContent: React.ReactNode;
   initiallyOpen?: boolean;
   placement?: Placement;
+  onClick?: (toggle: () => void, event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 
 const Context = React.createContext<{ closeDropdown: () => void }>({
@@ -108,6 +109,7 @@ const Dropdown: React.FC<Props> = ({
   initiallyOpen = false,
   zIndex = 1,
   children,
+  onClick,
   ...restProps
 }) => {
   const targetRef = React.createRef<HTMLDivElement>();
@@ -144,7 +146,13 @@ const Dropdown: React.FC<Props> = ({
         <Button
           pr={2}
           pl={2}
-          onClick={toggle}
+          onClick={(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+            if (typeof onClick === 'function') {
+              onClick(toggle, event);
+            } else {
+              toggle();
+            }
+          }}
           forcedState={isActive ? 'active' : null}
           {...(restProps as any)}
         >

--- a/packages/flame/src/Input/Input.tsx
+++ b/packages/flame/src/Input/Input.tsx
@@ -306,8 +306,8 @@ export interface InputProps extends Omit<BaseInputProps, 'status'> {
   status?:
     | StatusType
     | {
-        type: StatusType;
-        message: React.ReactNode;
+        type?: StatusType;
+        message?: React.ReactNode;
       };
   css?: any;
 }

--- a/packages/flame/src/InputGroup/InputGroup.tsx
+++ b/packages/flame/src/InputGroup/InputGroup.tsx
@@ -24,7 +24,7 @@ const InputGroupAddon = styled(Flex)<InputGroupAddonProps>`
   )};
 `;
 
-const InputGroup: React.FC = ({ children, ...restProps }) => {
+const InputGroup: React.FC<FlameFlexProps> = ({ children, ...restProps }) => {
   const nextChildren = React.Children.map(children, (child: any, index) => {
     if (index === 0) {
       return React.cloneElement(child, {

--- a/packages/flame/src/InputGroup/InputGroup.tsx
+++ b/packages/flame/src/InputGroup/InputGroup.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styled from '@emotion/styled';
 import { themeGet } from '@styled-system/theme-get';
-import { color, ColorProps, zIndex, ZIndexProps, compose } from 'styled-system';
+import { color, ColorProps, zIndex, ZIndexProps, compose, space } from 'styled-system';
 
 import { Flex, border, FlameFlexProps, BorderProps } from '../Core';
 
@@ -11,7 +11,8 @@ export interface InputGroupAddonProps
     Partial<Omit<ColorProps, 'color'>>,
     ZIndexProps {}
 const InputGroupAddon = styled(Flex)<InputGroupAddonProps>`
-  padding: ${themeGet('space.1')} ${themeGet('space.2')};
+  padding-left: ${themeGet('space.2')};
+  padding-right: ${themeGet('space.2')};
   text-align: center;
   background-color: ${themeGet('groupStyles.addon.background')};
   border: solid 1px ${themeGet('groupStyles.addon.borderColor')};
@@ -20,6 +21,7 @@ const InputGroupAddon = styled(Flex)<InputGroupAddonProps>`
   ${compose(
     border,
     color,
+    space,
     zIndex,
   )};
 `;


### PR DESCRIPTION
## Description

Passing an onClick handle on the Dropdown would override the toggle function. Now, we will always trigger the toggle, even when an onClick handler is passed.

Additionally, the InputGroup has been typed properly.

<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->
<!-- Closes #XXX -->

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [x] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [x] I have added tests that prove my fix is effective or that my feature works
