### PR TITLE
InputGroup early return if child is null

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Fixed
+
+- InputGroup will now properly manage null children, instead of throwing errors
+
 ## 1.2.0 - 2019-11-14
 
 ### Added

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -11,7 +11,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ### Fixed
 
-- InputGroup will now properly manage null children, instead of throwing errors
+- InputGroup will now properly manage null children, instead of throwing errors ([#43](https://github.com/lightspeed/flame/pull/43))
 
 ## 1.2.0 - 2019-11-14
 

--- a/packages/flame/src/InputGroup/InputGroup.tsx
+++ b/packages/flame/src/InputGroup/InputGroup.tsx
@@ -28,6 +28,10 @@ const InputGroupAddon = styled(Flex)<InputGroupAddonProps>`
 
 const InputGroup: React.FC<FlameFlexProps> = ({ children, ...restProps }) => {
   const nextChildren = React.Children.map(children, (child: any, index) => {
+    if (!child) {
+      return null;
+    }
+
     if (index === 0) {
       return React.cloneElement(child, {
         borderTopRightRadius: 0,


### PR DESCRIPTION
## Description

Funky scenarios where the child can be null which causes the InputGroup to go nuts. Bailing early will prevent issues caused by attempting to clone a null child.


## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [x] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [x] I have added tests that prove my fix is effective or that my feature works
