### PR TITLE
Input status null check to prevent crashes

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -11,7 +11,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ### Fixed
 
-- Input will no longer crash when status is set to null
+- Input will no longer crash when status is set to null ([#46](https://github.com/lightspeed/flame/pull/46))
 
 ## 1.2.1 - 2019-11-15
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Fixed
+
+- Input will no longer crash when status is set to null
+
 ## 1.2.1 - 2019-11-15
 
 ### Fixed

--- a/packages/flame/src/Input/Input.test.tsx
+++ b/packages/flame/src/Input/Input.test.tsx
@@ -30,6 +30,14 @@ describe('<Input />', () => {
     expect(element.type).toBe('text');
   });
 
+  it('should not crash on null status', () => {
+    const { getByPlaceholderText } = customRender(
+      <Input {...baseProps} status={null} placeholder="test-input" size="large" />,
+    );
+    const element: any = getByPlaceholderText('test-input');
+    expect(element.type).toBe('text');
+  });
+
   it('should forward the disabled property to the base input', () => {
     const { getByPlaceholderText } = customRender(
       <Input {...baseProps} disabled placeholder="test-input" size="small" />,

--- a/packages/flame/src/Input/Input.tsx
+++ b/packages/flame/src/Input/Input.tsx
@@ -318,8 +318,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ) => {
     const labelId = id && label ? `${id}-label` : undefined;
     const descriptionId = id && description ? `${id}-description` : undefined;
-    const nextStatus = typeof status === 'object' ? status.type : status;
-    const nextMessage = typeof status === 'object' ? status.message : statusMessage;
+    const nextStatus = status && typeof status === 'object' ? status.type : (status as StatusType);
+    const nextMessage = status && typeof status === 'object' ? status.message : statusMessage;
 
     if (typeof status === 'object') {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
## Description

Input status null check to prevent crashes

<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->
<!-- Closes #XXX -->

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Set input status to null

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [x] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [x] I have added tests that prove my fix is effective or that my feature works
