### PR TITLE
Removed excessive console.warn from Group and Input

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,4 +6,4 @@ coverage:
         target: 75%
     project:
       default:
-        target: auto
+        target: 85%

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -11,7 +11,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ### Fixed
 
-- Removed excessive `console.warn` from Group and Input
+- Removed excessive `console.warn` from Group and Input ([#47](https://github.com/lightspeed/flame/pull/47))
 
 ## 1.2.2 - 2019-11-21
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Fixed
+
+- Removed excessive `console.warn` from Group and Input
+
 ## 1.2.2 - 2019-11-21
 
 ### Fixed

--- a/packages/flame/src/Group/Group.tsx
+++ b/packages/flame/src/Group/Group.tsx
@@ -31,15 +31,6 @@ export const GroupItem = styled('div')<GroupItemProps>`
 
   ${flexbox};
   ${layout};
-  ${() => {
-    // eslint-disable-next-line no-console
-    console.warn(`
-DEPRECATION WARNING
-GroupItem will be removed in the next major version of Flame.
-Please rely on using Flex and Box components for wrapping things properly.
-    `);
-    return '';
-  }};
 `;
 
 // @ts-ignore
@@ -100,15 +91,6 @@ export const GroupAddon = styled('div')<GroupAddonProps>`
   ${horizontalAlignment};
 
   ${layout};
-  ${() => {
-    // eslint-disable-next-line no-console
-    console.warn(`
-DEPRECATION WARNING
-GroupAddon will be removed in the next major version of Flame.
-Please rely on InputGroup and the InputGroupAddon component.
-    `);
-    return '';
-  }};
 `;
 
 // @ts-ignore
@@ -253,12 +235,6 @@ export const Group: React.FunctionComponent<GroupProps> = ({
   inputBlock,
   ...restProps
 }) => {
-  // eslint-disable-next-line no-console
-  console.warn(`
-DEPRECATION WARNING
-Group will be removed in the next major version of Flame.
-Please use SpacedGroup or InputGroup instead.
-  `);
   const wrappedChildren = React.Children.map(children, (child: any) => {
     if (
       child &&

--- a/packages/flame/src/Input/Input.tsx
+++ b/packages/flame/src/Input/Input.tsx
@@ -321,15 +321,6 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     const nextStatus = status && typeof status === 'object' ? status.type : (status as StatusType);
     const nextMessage = status && typeof status === 'object' ? status.message : statusMessage;
 
-    if (typeof status === 'object') {
-      // eslint-disable-next-line no-console
-      console.warn(`
-Using status as an object will be deprecated in the next version of Flame.
-Please prefer passing the status.type to the status prop directly and
-pass the status.message to the statusMessage prop.
-`);
-    }
-
     return (
       <React.Fragment>
         {label && (


### PR DESCRIPTION
## Description

Things are getting a bit too noisy. I'll instead do a post on the upcoming changes and plan a proper migration guide instead of polluting the console.