### PR TITLE
Make switch more mobile friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "percy": "build-storybook -c .storybook && percy-storybook --widths=1280"
   },
   "dependencies": {
-    "@emotion/core": "^10.0.9",
-    "@emotion/styled": "^10.0.9",
-    "@styled-system/theme-get": "5.0.16",
+    "@emotion/core": "^10.0.22",
+    "@emotion/styled": "^10.0.23",
+    "@styled-system/theme-get": "5.1.2",
     "classnames": "^2.2.5",
     "emotion-theming": "^10.0.7",
     "polished": "^2.3.0",
@@ -80,7 +80,8 @@
     "@types/storybook-readme": "^5.0.3",
     "@types/storybook__addon-actions": "^3.4.3",
     "@types/storybook__react": "^4.0.2",
-    "@types/styled-system": "^5.0.0",
+    "@types/styled-system": "^5.1.4",
+    "@types/styled-system__css": "^5.0.4",
     "array-move": "^2.1.0",
     "autoprefixer": "^8.0.0",
     "babel-eslint": "^10.0.1",

--- a/packages/flame/package.json
+++ b/packages/flame/package.json
@@ -35,8 +35,10 @@
     "release:dryrun": "npm publish dist --dry-run"
   },
   "dependencies": {
+    "@styled-system/css": "^5.0.23",
     "@styled-system/theme-get": "5.0.16",
     "@types/styled-system": "^5.0.0",
+    "@types/styled-system__css": "^5.0.4",
     "polished": "^2.3.0",
     "popper.js": "^1.15.0",
     "react-modal": "^3.5.1",

--- a/packages/flame/src/Checkbox/index.tsx
+++ b/packages/flame/src/Checkbox/index.tsx
@@ -4,14 +4,6 @@ import {
   Checkbox,
   CheckboxProps,
   CheckboxLabel,
-  CheckboxDescriptionProps,
 } from './Checkbox';
 
-export {
-  BaseCheckbox,
-  BaseCheckboxProps,
-  Checkbox,
-  CheckboxProps,
-  CheckboxLabel,
-  CheckboxDescriptionProps,
-};
+export { BaseCheckbox, BaseCheckboxProps, Checkbox, CheckboxProps, CheckboxLabel };

--- a/packages/flame/src/Core/index.tsx
+++ b/packages/flame/src/Core/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Global, css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { ThemeProvider } from 'emotion-theming';
+import { css as styledSystemCss } from '@styled-system/css';
 import { Omit } from 'type-fest';
 
 import {
@@ -142,6 +143,22 @@ const FlameGlobalStyles: React.FunctionComponent<{ themeName?: string }> = ({ th
   );
 };
 
+const get = (theme: object) => (path: string) => themeGet(path)({ theme });
+type flameCssCallback = (get: (path: string) => any, theme: object) => object;
+/**
+ * flameCss
+ * @description
+ * Augmented version of styled-system/css with a pre-bound themeGet to safely access
+ * token values
+ *
+ * Note:
+ * Use the return type `any` for now until styled-system/css has fixed their wonky typing
+ * issues with css props
+ */
+const flameCss = (cb: flameCssCallback): any => {
+  return styledSystemCss(theme => cb(get(theme), get));
+};
+
 export {
   lightTheme,
   flameTheme,
@@ -150,5 +167,6 @@ export {
   FlameGlobalStyles,
   themeGet,
   ThemeUIFlame,
+  flameCss as css,
   border,
 };

--- a/packages/flame/src/Switch/Switch.tsx
+++ b/packages/flame/src/Switch/Switch.tsx
@@ -1,113 +1,73 @@
 import * as React from 'react';
-import styled from '@emotion/styled';
-import { themeGet } from '@styled-system/theme-get';
 import { Merge } from 'type-fest';
+import { css } from '../Core';
 import { IconCheckmark } from '../Icon/Checkmark';
 import { IconCross } from '../Icon/Cross';
 
-const SwitchWrapper = styled('span')`
-  display: flex;
-  justify-content: space-between;
-  width: ${themeGet('space.8')};
-  height: ${themeGet('space.4')};
-  box-sizing: border-box;
-  border: solid 1px ${themeGet('switchStyles.off.border')};
-  border-radius: ${themeGet('space.2')};
-  background: ${themeGet('switchStyles.off.background')};
-  transition-property: background;
-  transition-duration: ${themeGet('transition.transition-duration-slow')};
-  transition-timing-function: cubic-bezier(0.68, 1.46, 0.1, 1.06);
-`;
-
-const WrapperLabel = styled('label')`
-  position: relative;
-  display: inline-block;
-  cursor: pointer;
-`;
-
-const SwitchSlider = styled('span')`
-  display: flex;
-  justify-content: center;
-  align-self: center;
-  position: absolute;
-  top: calc(${themeGet('space.1')} / 2);
-  width: calc(${themeGet('space.4')} - ${themeGet('space.1')});
-  height: calc(${themeGet('space.4')} - ${themeGet('space.1')});
-  margin: 0 2px;
-  box-sizing: border-box;
-  border: solid 1px ${themeGet('switchStyles.slider.border')};
-  border-radius: ${themeGet('radii.radius-circle')};
-  background: ${themeGet('switchStyles.slider.background')};
-  z-index: 2;
-  box-shadow: ${themeGet('switchStyles.slider.shadow')};
-  transition-property: translateX(0);
-  transition-duration: ${themeGet('transition.transition-duration-slow')};
-  transition-timing-function: cubic-bezier(0.68, 1.46, 0.1, 1.06);
-`;
-
-const Svg = styled('svg')`
-  align-self: center;
-`;
-
-const SwitchSliderIcon = () => (
-  <Svg width="10" height="2" xmlns="http://www.w3.org/2000/svg">
+const SwitchSliderIcon: React.FC = () => (
+  <svg css={{ alignSelf: 'center' }} width="10" height="2" xmlns="http://www.w3.org/2000/svg">
     <path
       d="M0 .505C0 .226.232 0 .5 0c.276 0 .5.214.5.505v.99A.508.508 0 0 1 .5 2a.495.495 0 0 1-.5-.505v-.99zm3 0C3 .226 3.232 0 3.5 0c.276 0 .5.214.5.505v.99A.508.508 0 0 1 3.5 2a.495.495 0 0 1-.5-.505v-.99zm3 0C6 .226 6.232 0 6.5 0c.276 0 .5.214.5.505v.99A.508.508 0 0 1 6.5 2a.495.495 0 0 1-.5-.505v-.99zm3 0C9 .226 9.232 0 9.5 0c.276 0 .5.214.5.505v.99A.508.508 0 0 1 9.5 2a.495.495 0 0 1-.5-.505v-.99z"
       fill="#C4CACC"
       fillRule="evenodd"
     />
-  </Svg>
+  </svg>
 );
 
-const SwitchInput = styled('input')`
-  opacity: 0;
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  margin: 0;
-  z-index: 3;
-  cursor: pointer;
-
-  &:checked + ${SwitchWrapper} {
-    background: ${themeGet('switchStyles.on.background')};
-    border-color: ${themeGet('switchStyles.on.checkedBorder')};
-
-    ${SwitchSlider} {
-      transform: translateX(1.5rem);
-      border-color: ${themeGet('switchStyles.on.border')};
+const SwitchBackgroundIcons: React.FC = () => (
+  <span
+    css={
+      css(get => ({
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignSelf: 'center',
+        width: '100%',
+        margin: `0 ${get('space.1')}`,
+        zIndex: 1,
+      })) as any
     }
-  }
+  >
+    <IconCheckmark
+      size="0.75rem"
+      css={css(get => ({
+        fill: get('switchStyles.icons.checkmarkBackground'),
+      }))}
+    />
+    <IconCross
+      size="0.75rem"
+      css={css(get => ({
+        fill: get('switchStyles.icons.crossBackground'),
+      }))}
+    />
+  </span>
+);
 
-  &:focus + ${SwitchWrapper} {
-    box-shadow: 0 0 0 1pt ${themeGet('switchStyles.on.color')},
-      0 0 0 3pt ${themeGet('switchStyles.on.background')};
-  }
-
-  &:disabled {
-    cursor: default;
-
-    & + ${SwitchWrapper} {
-      opacity: 0.5;
-    }
-  }
-`;
-
-const IconWrapper = styled('span')`
-  display: flex;
-  justify-content: space-between;
-  align-self: center;
-  width: 100%;
-  margin: 0 ${themeGet('space.1')};
-  z-index: 1;
-`;
-
-const Checkmark = styled(IconCheckmark)`
-  fill: ${themeGet('switchStyles.icons.checkmarkBackground')};
-`;
-
-const Cross = styled(IconCross)`
-  fill: ${themeGet('switchStyles.icons.crossBackground')};
-`;
+const SwitchSlider: React.FC = ({ children }) => (
+  <span
+    className="fl-switch__slider"
+    css={css(get => ({
+      display: 'flex',
+      justifyContent: 'center',
+      alignSelf: 'center',
+      position: 'absolute',
+      margin: '0 2px',
+      top: ['3px', '3px'],
+      width: ['24px', '18px'],
+      height: ['24px', '18px'],
+      boxSizing: 'border-box',
+      border: `solid 1px ${get('switchStyles.slider.border')}`,
+      borderRadius: get('radii.radius-circle'),
+      background: get('switchStyles.slider.background'),
+      zIndex: 2,
+      boxShadow: get('switchStyles.slider.shadow'),
+      transitionProperty: 'translateX(0)',
+      transitionDuration: get('transition.transition-duration-slow'),
+      transitionTimingFunction: 'cubic-bezier(0.68, 1.46, 0.1, 1.06)',
+    }))}
+  >
+    {children}
+  </span>
+);
 
 export type SwitchProps = Merge<
   React.HTMLProps<HTMLInputElement>,
@@ -119,19 +79,73 @@ export type SwitchProps = Merge<
     checked?: boolean;
   }
 >;
-const Switch: React.FC<SwitchProps> = ({ className, checked, ...restProps }) => (
-  <WrapperLabel role="presentation" className={className}>
-    <SwitchInput type="checkbox" checked={checked} value={checked ? 1 : 0} {...restProps} />
-    <SwitchWrapper>
+const Switch: React.FC<SwitchProps> = ({ className, checked, id, ...restProps }) => (
+  <label
+    htmlFor={id}
+    className={className}
+    css={{
+      position: 'relative',
+      display: 'inline-block',
+      cursor: 'pointer',
+    }}
+  >
+    <input
+      id={id}
+      css={css(get => ({
+        opacity: 0,
+        position: 'absolute',
+        width: '100%',
+        height: '100%',
+        margin: 0,
+        zIndex: 3,
+        cursor: 'pointer',
+        '&:checked + .fl-switch__wrapper': {
+          background: get('switchStyles.on.background'),
+          borderColor: get('switchStyles.on.checkedBorder'),
+          '.fl-switch__slider': {
+            transform: 'translateX(1.5rem)',
+            borderColor: get('switchStyles.on.border'),
+          },
+        },
+        '&:focus + .fl-switch__wrapper': {
+          boxShadow: `0 0 0 1pt ${get('switchStyles.on.color')}, 0 0 0 3pt ${get(
+            'switchStyles.on.background',
+          )}`,
+        },
+        '&:disabled': {
+          cursor: 'default',
+          '& + .fl-switch__wrapper': {
+            opacity: 0.5,
+          },
+        },
+      }))}
+      type="checkbox"
+      checked={checked}
+      value={checked ? 1 : 0}
+      {...restProps}
+    />
+    <span
+      className="fl-switch__wrapper"
+      css={css(get => ({
+        width: [get('space.9'), get('space.8')],
+        height: [get('space.5'), get('space.4')],
+        display: 'flex',
+        justifyContent: 'space-between',
+        boxSizing: 'border-box',
+        border: `solid 1px ${get('switchStyles.off.border')}`,
+        borderRadius: [get('space.3'), get('space.2')],
+        background: get('switchStyles.off.background'),
+        transitionProperty: 'background',
+        transitionDuration: get('transition.transition-duration-slow'),
+        transitionTimingFunction: 'cubic-bezier(0.68, 1.46, 0.1, 1.06)',
+      }))}
+    >
       <SwitchSlider>
         <SwitchSliderIcon />
       </SwitchSlider>
-      <IconWrapper>
-        <Checkmark size="0.75rem" />
-        <Cross size="0.75rem" />
-      </IconWrapper>
-    </SwitchWrapper>
-  </WrapperLabel>
+      <SwitchBackgroundIcons />
+    </span>
+  </label>
 );
 
 export { Switch };

--- a/packages/flame/src/Switch/__snapshots__/Switch.test.tsx.snap
+++ b/packages/flame/src/Switch/__snapshots__/Switch.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Switch /> when autoFocus should render correctly 1`] = `
-.emotion-16 {
+.emotion-9 {
   position: relative;
   display: inline-block;
   cursor: pointer;
@@ -17,19 +17,19 @@ exports[`<Switch /> when autoFocus should render correctly 1`] = `
   cursor: pointer;
 }
 
-.emotion-0:checked + .emotion-15 {
+.emotion-0:checked + .fl-switch__wrapper {
   background: #2875c6;
   border-color: #1d5794;
 }
 
-.emotion-0:checked + .emotion-15 .emotion-5 {
+.emotion-0:checked + .fl-switch__wrapper .fl-switch__slider {
   -webkit-transform: translateX(1.5rem);
   -ms-transform: translateX(1.5rem);
   transform: translateX(1.5rem);
   border-color: #1d5794;
 }
 
-.emotion-0:focus + .emotion-15 {
+.emotion-0:focus + .fl-switch__wrapper {
   box-shadow: 0 0 0 1pt #fff,0 0 0 3pt #2875c6;
 }
 
@@ -37,11 +37,13 @@ exports[`<Switch /> when autoFocus should render correctly 1`] = `
   cursor: default;
 }
 
-.emotion-0:disabled + .emotion-15 {
+.emotion-0:disabled + .fl-switch__wrapper {
   opacity: 0.5;
 }
 
-.emotion-14 {
+.emotion-8 {
+  width: 3.375rem;
+  height: 1.875rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -50,11 +52,9 @@ exports[`<Switch /> when autoFocus should render correctly 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 3rem;
-  height: 1.5rem;
   box-sizing: border-box;
   border: solid 1px #abb3b3;
-  border-radius: 0.75rem;
+  border-radius: 1.125rem;
   background: #fff;
   -webkit-transition-property: background;
   transition-property: background;
@@ -64,7 +64,15 @@ exports[`<Switch /> when autoFocus should render correctly 1`] = `
   transition-timing-function: cubic-bezier(0.68,1.46,0.1,1.06);
 }
 
-.emotion-4 {
+@media screen and (min-width:601px) {
+  .emotion-8 {
+    width: 3rem;
+    height: 1.5rem;
+    border-radius: 0.75rem;
+  }
+}
+
+.emotion-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -77,10 +85,10 @@ exports[`<Switch /> when autoFocus should render correctly 1`] = `
   -ms-flex-item-align: center;
   align-self: center;
   position: absolute;
-  top: calc(0.375rem / 2);
-  width: calc(1.5rem - 0.375rem);
-  height: calc(1.5rem - 0.375rem);
   margin: 0 2px;
+  top: 3px;
+  width: 24px;
+  height: 24px;
   box-sizing: border-box;
   border: solid 1px #abb3b3;
   border-radius: 50%;
@@ -95,13 +103,21 @@ exports[`<Switch /> when autoFocus should render correctly 1`] = `
   transition-timing-function: cubic-bezier(0.68,1.46,0.1,1.06);
 }
 
-.emotion-2 {
+@media screen and (min-width:601px) {
+  .emotion-2 {
+    top: 3px;
+    width: 18px;
+    height: 18px;
+  }
+}
+
+.emotion-1 {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.emotion-12 {
+.emotion-7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -118,14 +134,14 @@ exports[`<Switch /> when autoFocus should render correctly 1`] = `
   z-index: 1;
 }
 
-.emotion-7 {
+.emotion-3 {
   vertical-align: text-bottom;
   width: 0.75rem;
   height: 0.75rem;
   fill: #fff;
 }
 
-.emotion-10 {
+.emotion-5 {
   vertical-align: text-bottom;
   width: 0.75rem;
   height: 0.75rem;
@@ -133,23 +149,22 @@ exports[`<Switch /> when autoFocus should render correctly 1`] = `
 }
 
 <label
-  className="emotion-16 emotion-17"
-  role="presentation"
+  className="emotion-9"
 >
   <input
     autoFocus={true}
-    className="emotion-0 emotion-1"
+    className="emotion-0"
     type="checkbox"
     value={0}
   />
   <span
-    className="emotion-14 emotion-15"
+    className="fl-switch__wrapper emotion-8"
   >
     <span
-      className="emotion-4 emotion-5"
+      className="fl-switch__slider emotion-2"
     >
       <svg
-        className="emotion-2 emotion-3"
+        className="emotion-1"
         height="2"
         width="10"
         xmlns="http://www.w3.org/2000/svg"
@@ -162,10 +177,10 @@ exports[`<Switch /> when autoFocus should render correctly 1`] = `
       </svg>
     </span>
     <span
-      className="emotion-12 emotion-13"
+      className="emotion-7"
     >
       <svg
-        className="emotion-6 cr-icon emotion-7 emotion-8"
+        className="cr-icon emotion-3 emotion-4"
         height="0.75rem"
         viewBox="0 0 16 16"
         width="0.75rem"
@@ -177,7 +192,7 @@ exports[`<Switch /> when autoFocus should render correctly 1`] = `
         />
       </svg>
       <svg
-        className="emotion-9 cr-icon emotion-10 emotion-8"
+        className="cr-icon emotion-5 emotion-4"
         height="0.75rem"
         viewBox="0 0 16 16"
         width="0.75rem"
@@ -194,7 +209,7 @@ exports[`<Switch /> when autoFocus should render correctly 1`] = `
 `;
 
 exports[`<Switch /> when checked should render correctly 1`] = `
-.emotion-16 {
+.emotion-9 {
   position: relative;
   display: inline-block;
   cursor: pointer;
@@ -210,19 +225,19 @@ exports[`<Switch /> when checked should render correctly 1`] = `
   cursor: pointer;
 }
 
-.emotion-0:checked + .emotion-15 {
+.emotion-0:checked + .fl-switch__wrapper {
   background: #2875c6;
   border-color: #1d5794;
 }
 
-.emotion-0:checked + .emotion-15 .emotion-5 {
+.emotion-0:checked + .fl-switch__wrapper .fl-switch__slider {
   -webkit-transform: translateX(1.5rem);
   -ms-transform: translateX(1.5rem);
   transform: translateX(1.5rem);
   border-color: #1d5794;
 }
 
-.emotion-0:focus + .emotion-15 {
+.emotion-0:focus + .fl-switch__wrapper {
   box-shadow: 0 0 0 1pt #fff,0 0 0 3pt #2875c6;
 }
 
@@ -230,11 +245,13 @@ exports[`<Switch /> when checked should render correctly 1`] = `
   cursor: default;
 }
 
-.emotion-0:disabled + .emotion-15 {
+.emotion-0:disabled + .fl-switch__wrapper {
   opacity: 0.5;
 }
 
-.emotion-14 {
+.emotion-8 {
+  width: 3.375rem;
+  height: 1.875rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -243,11 +260,9 @@ exports[`<Switch /> when checked should render correctly 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 3rem;
-  height: 1.5rem;
   box-sizing: border-box;
   border: solid 1px #abb3b3;
-  border-radius: 0.75rem;
+  border-radius: 1.125rem;
   background: #fff;
   -webkit-transition-property: background;
   transition-property: background;
@@ -257,7 +272,15 @@ exports[`<Switch /> when checked should render correctly 1`] = `
   transition-timing-function: cubic-bezier(0.68,1.46,0.1,1.06);
 }
 
-.emotion-4 {
+@media screen and (min-width:601px) {
+  .emotion-8 {
+    width: 3rem;
+    height: 1.5rem;
+    border-radius: 0.75rem;
+  }
+}
+
+.emotion-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -270,10 +293,10 @@ exports[`<Switch /> when checked should render correctly 1`] = `
   -ms-flex-item-align: center;
   align-self: center;
   position: absolute;
-  top: calc(0.375rem / 2);
-  width: calc(1.5rem - 0.375rem);
-  height: calc(1.5rem - 0.375rem);
   margin: 0 2px;
+  top: 3px;
+  width: 24px;
+  height: 24px;
   box-sizing: border-box;
   border: solid 1px #abb3b3;
   border-radius: 50%;
@@ -288,13 +311,21 @@ exports[`<Switch /> when checked should render correctly 1`] = `
   transition-timing-function: cubic-bezier(0.68,1.46,0.1,1.06);
 }
 
-.emotion-2 {
+@media screen and (min-width:601px) {
+  .emotion-2 {
+    top: 3px;
+    width: 18px;
+    height: 18px;
+  }
+}
+
+.emotion-1 {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.emotion-12 {
+.emotion-7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -311,14 +342,14 @@ exports[`<Switch /> when checked should render correctly 1`] = `
   z-index: 1;
 }
 
-.emotion-7 {
+.emotion-3 {
   vertical-align: text-bottom;
   width: 0.75rem;
   height: 0.75rem;
   fill: #fff;
 }
 
-.emotion-10 {
+.emotion-5 {
   vertical-align: text-bottom;
   width: 0.75rem;
   height: 0.75rem;
@@ -326,23 +357,22 @@ exports[`<Switch /> when checked should render correctly 1`] = `
 }
 
 <label
-  className="emotion-16 emotion-17"
-  role="presentation"
+  className="emotion-9"
 >
   <input
     checked={true}
-    className="emotion-0 emotion-1"
+    className="emotion-0"
     type="checkbox"
     value={1}
   />
   <span
-    className="emotion-14 emotion-15"
+    className="fl-switch__wrapper emotion-8"
   >
     <span
-      className="emotion-4 emotion-5"
+      className="fl-switch__slider emotion-2"
     >
       <svg
-        className="emotion-2 emotion-3"
+        className="emotion-1"
         height="2"
         width="10"
         xmlns="http://www.w3.org/2000/svg"
@@ -355,10 +385,10 @@ exports[`<Switch /> when checked should render correctly 1`] = `
       </svg>
     </span>
     <span
-      className="emotion-12 emotion-13"
+      className="emotion-7"
     >
       <svg
-        className="emotion-6 cr-icon emotion-7 emotion-8"
+        className="cr-icon emotion-3 emotion-4"
         height="0.75rem"
         viewBox="0 0 16 16"
         width="0.75rem"
@@ -370,7 +400,7 @@ exports[`<Switch /> when checked should render correctly 1`] = `
         />
       </svg>
       <svg
-        className="emotion-9 cr-icon emotion-10 emotion-8"
+        className="cr-icon emotion-5 emotion-4"
         height="0.75rem"
         viewBox="0 0 16 16"
         width="0.75rem"
@@ -387,7 +417,7 @@ exports[`<Switch /> when checked should render correctly 1`] = `
 `;
 
 exports[`<Switch /> when disabled should render correctly 1`] = `
-.emotion-16 {
+.emotion-9 {
   position: relative;
   display: inline-block;
   cursor: pointer;
@@ -403,19 +433,19 @@ exports[`<Switch /> when disabled should render correctly 1`] = `
   cursor: pointer;
 }
 
-.emotion-0:checked + .emotion-15 {
+.emotion-0:checked + .fl-switch__wrapper {
   background: #2875c6;
   border-color: #1d5794;
 }
 
-.emotion-0:checked + .emotion-15 .emotion-5 {
+.emotion-0:checked + .fl-switch__wrapper .fl-switch__slider {
   -webkit-transform: translateX(1.5rem);
   -ms-transform: translateX(1.5rem);
   transform: translateX(1.5rem);
   border-color: #1d5794;
 }
 
-.emotion-0:focus + .emotion-15 {
+.emotion-0:focus + .fl-switch__wrapper {
   box-shadow: 0 0 0 1pt #fff,0 0 0 3pt #2875c6;
 }
 
@@ -423,11 +453,13 @@ exports[`<Switch /> when disabled should render correctly 1`] = `
   cursor: default;
 }
 
-.emotion-0:disabled + .emotion-15 {
+.emotion-0:disabled + .fl-switch__wrapper {
   opacity: 0.5;
 }
 
-.emotion-14 {
+.emotion-8 {
+  width: 3.375rem;
+  height: 1.875rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -436,11 +468,9 @@ exports[`<Switch /> when disabled should render correctly 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 3rem;
-  height: 1.5rem;
   box-sizing: border-box;
   border: solid 1px #abb3b3;
-  border-radius: 0.75rem;
+  border-radius: 1.125rem;
   background: #fff;
   -webkit-transition-property: background;
   transition-property: background;
@@ -450,7 +480,15 @@ exports[`<Switch /> when disabled should render correctly 1`] = `
   transition-timing-function: cubic-bezier(0.68,1.46,0.1,1.06);
 }
 
-.emotion-4 {
+@media screen and (min-width:601px) {
+  .emotion-8 {
+    width: 3rem;
+    height: 1.5rem;
+    border-radius: 0.75rem;
+  }
+}
+
+.emotion-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -463,10 +501,10 @@ exports[`<Switch /> when disabled should render correctly 1`] = `
   -ms-flex-item-align: center;
   align-self: center;
   position: absolute;
-  top: calc(0.375rem / 2);
-  width: calc(1.5rem - 0.375rem);
-  height: calc(1.5rem - 0.375rem);
   margin: 0 2px;
+  top: 3px;
+  width: 24px;
+  height: 24px;
   box-sizing: border-box;
   border: solid 1px #abb3b3;
   border-radius: 50%;
@@ -481,13 +519,21 @@ exports[`<Switch /> when disabled should render correctly 1`] = `
   transition-timing-function: cubic-bezier(0.68,1.46,0.1,1.06);
 }
 
-.emotion-2 {
+@media screen and (min-width:601px) {
+  .emotion-2 {
+    top: 3px;
+    width: 18px;
+    height: 18px;
+  }
+}
+
+.emotion-1 {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.emotion-12 {
+.emotion-7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -504,14 +550,14 @@ exports[`<Switch /> when disabled should render correctly 1`] = `
   z-index: 1;
 }
 
-.emotion-7 {
+.emotion-3 {
   vertical-align: text-bottom;
   width: 0.75rem;
   height: 0.75rem;
   fill: #fff;
 }
 
-.emotion-10 {
+.emotion-5 {
   vertical-align: text-bottom;
   width: 0.75rem;
   height: 0.75rem;
@@ -519,23 +565,22 @@ exports[`<Switch /> when disabled should render correctly 1`] = `
 }
 
 <label
-  className="emotion-16 emotion-17"
-  role="presentation"
+  className="emotion-9"
 >
   <input
-    className="emotion-0 emotion-1"
+    className="emotion-0"
     disabled={true}
     type="checkbox"
     value={0}
   />
   <span
-    className="emotion-14 emotion-15"
+    className="fl-switch__wrapper emotion-8"
   >
     <span
-      className="emotion-4 emotion-5"
+      className="fl-switch__slider emotion-2"
     >
       <svg
-        className="emotion-2 emotion-3"
+        className="emotion-1"
         height="2"
         width="10"
         xmlns="http://www.w3.org/2000/svg"
@@ -548,10 +593,10 @@ exports[`<Switch /> when disabled should render correctly 1`] = `
       </svg>
     </span>
     <span
-      className="emotion-12 emotion-13"
+      className="emotion-7"
     >
       <svg
-        className="emotion-6 cr-icon emotion-7 emotion-8"
+        className="cr-icon emotion-3 emotion-4"
         height="0.75rem"
         viewBox="0 0 16 16"
         width="0.75rem"
@@ -563,7 +608,7 @@ exports[`<Switch /> when disabled should render correctly 1`] = `
         />
       </svg>
       <svg
-        className="emotion-9 cr-icon emotion-10 emotion-8"
+        className="cr-icon emotion-5 emotion-4"
         height="0.75rem"
         viewBox="0 0 16 16"
         width="0.75rem"
@@ -580,7 +625,7 @@ exports[`<Switch /> when disabled should render correctly 1`] = `
 `;
 
 exports[`<Switch /> when empty props should render correctly 1`] = `
-.emotion-16 {
+.emotion-9 {
   position: relative;
   display: inline-block;
   cursor: pointer;
@@ -596,19 +641,19 @@ exports[`<Switch /> when empty props should render correctly 1`] = `
   cursor: pointer;
 }
 
-.emotion-0:checked + .emotion-15 {
+.emotion-0:checked + .fl-switch__wrapper {
   background: #2875c6;
   border-color: #1d5794;
 }
 
-.emotion-0:checked + .emotion-15 .emotion-5 {
+.emotion-0:checked + .fl-switch__wrapper .fl-switch__slider {
   -webkit-transform: translateX(1.5rem);
   -ms-transform: translateX(1.5rem);
   transform: translateX(1.5rem);
   border-color: #1d5794;
 }
 
-.emotion-0:focus + .emotion-15 {
+.emotion-0:focus + .fl-switch__wrapper {
   box-shadow: 0 0 0 1pt #fff,0 0 0 3pt #2875c6;
 }
 
@@ -616,11 +661,13 @@ exports[`<Switch /> when empty props should render correctly 1`] = `
   cursor: default;
 }
 
-.emotion-0:disabled + .emotion-15 {
+.emotion-0:disabled + .fl-switch__wrapper {
   opacity: 0.5;
 }
 
-.emotion-14 {
+.emotion-8 {
+  width: 3.375rem;
+  height: 1.875rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -629,11 +676,9 @@ exports[`<Switch /> when empty props should render correctly 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 3rem;
-  height: 1.5rem;
   box-sizing: border-box;
   border: solid 1px #abb3b3;
-  border-radius: 0.75rem;
+  border-radius: 1.125rem;
   background: #fff;
   -webkit-transition-property: background;
   transition-property: background;
@@ -643,7 +688,15 @@ exports[`<Switch /> when empty props should render correctly 1`] = `
   transition-timing-function: cubic-bezier(0.68,1.46,0.1,1.06);
 }
 
-.emotion-4 {
+@media screen and (min-width:601px) {
+  .emotion-8 {
+    width: 3rem;
+    height: 1.5rem;
+    border-radius: 0.75rem;
+  }
+}
+
+.emotion-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -656,10 +709,10 @@ exports[`<Switch /> when empty props should render correctly 1`] = `
   -ms-flex-item-align: center;
   align-self: center;
   position: absolute;
-  top: calc(0.375rem / 2);
-  width: calc(1.5rem - 0.375rem);
-  height: calc(1.5rem - 0.375rem);
   margin: 0 2px;
+  top: 3px;
+  width: 24px;
+  height: 24px;
   box-sizing: border-box;
   border: solid 1px #abb3b3;
   border-radius: 50%;
@@ -674,13 +727,21 @@ exports[`<Switch /> when empty props should render correctly 1`] = `
   transition-timing-function: cubic-bezier(0.68,1.46,0.1,1.06);
 }
 
-.emotion-2 {
+@media screen and (min-width:601px) {
+  .emotion-2 {
+    top: 3px;
+    width: 18px;
+    height: 18px;
+  }
+}
+
+.emotion-1 {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.emotion-12 {
+.emotion-7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -697,14 +758,14 @@ exports[`<Switch /> when empty props should render correctly 1`] = `
   z-index: 1;
 }
 
-.emotion-7 {
+.emotion-3 {
   vertical-align: text-bottom;
   width: 0.75rem;
   height: 0.75rem;
   fill: #fff;
 }
 
-.emotion-10 {
+.emotion-5 {
   vertical-align: text-bottom;
   width: 0.75rem;
   height: 0.75rem;
@@ -712,22 +773,21 @@ exports[`<Switch /> when empty props should render correctly 1`] = `
 }
 
 <label
-  className="emotion-16 emotion-17"
-  role="presentation"
+  className="emotion-9"
 >
   <input
-    className="emotion-0 emotion-1"
+    className="emotion-0"
     type="checkbox"
     value={0}
   />
   <span
-    className="emotion-14 emotion-15"
+    className="fl-switch__wrapper emotion-8"
   >
     <span
-      className="emotion-4 emotion-5"
+      className="fl-switch__slider emotion-2"
     >
       <svg
-        className="emotion-2 emotion-3"
+        className="emotion-1"
         height="2"
         width="10"
         xmlns="http://www.w3.org/2000/svg"
@@ -740,10 +800,10 @@ exports[`<Switch /> when empty props should render correctly 1`] = `
       </svg>
     </span>
     <span
-      className="emotion-12 emotion-13"
+      className="emotion-7"
     >
       <svg
-        className="emotion-6 cr-icon emotion-7 emotion-8"
+        className="cr-icon emotion-3 emotion-4"
         height="0.75rem"
         viewBox="0 0 16 16"
         width="0.75rem"
@@ -755,7 +815,7 @@ exports[`<Switch /> when empty props should render correctly 1`] = `
         />
       </svg>
       <svg
-        className="emotion-9 cr-icon emotion-10 emotion-8"
+        className="cr-icon emotion-5 emotion-4"
         height="0.75rem"
         viewBox="0 0 16 16"
         width="0.75rem"
@@ -772,7 +832,7 @@ exports[`<Switch /> when empty props should render correctly 1`] = `
 `;
 
 exports[`<Switch /> when id, name should render correctly 1`] = `
-.emotion-16 {
+.emotion-9 {
   position: relative;
   display: inline-block;
   cursor: pointer;
@@ -788,19 +848,19 @@ exports[`<Switch /> when id, name should render correctly 1`] = `
   cursor: pointer;
 }
 
-.emotion-0:checked + .emotion-15 {
+.emotion-0:checked + .fl-switch__wrapper {
   background: #2875c6;
   border-color: #1d5794;
 }
 
-.emotion-0:checked + .emotion-15 .emotion-5 {
+.emotion-0:checked + .fl-switch__wrapper .fl-switch__slider {
   -webkit-transform: translateX(1.5rem);
   -ms-transform: translateX(1.5rem);
   transform: translateX(1.5rem);
   border-color: #1d5794;
 }
 
-.emotion-0:focus + .emotion-15 {
+.emotion-0:focus + .fl-switch__wrapper {
   box-shadow: 0 0 0 1pt #fff,0 0 0 3pt #2875c6;
 }
 
@@ -808,11 +868,13 @@ exports[`<Switch /> when id, name should render correctly 1`] = `
   cursor: default;
 }
 
-.emotion-0:disabled + .emotion-15 {
+.emotion-0:disabled + .fl-switch__wrapper {
   opacity: 0.5;
 }
 
-.emotion-14 {
+.emotion-8 {
+  width: 3.375rem;
+  height: 1.875rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -821,11 +883,9 @@ exports[`<Switch /> when id, name should render correctly 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 3rem;
-  height: 1.5rem;
   box-sizing: border-box;
   border: solid 1px #abb3b3;
-  border-radius: 0.75rem;
+  border-radius: 1.125rem;
   background: #fff;
   -webkit-transition-property: background;
   transition-property: background;
@@ -835,7 +895,15 @@ exports[`<Switch /> when id, name should render correctly 1`] = `
   transition-timing-function: cubic-bezier(0.68,1.46,0.1,1.06);
 }
 
-.emotion-4 {
+@media screen and (min-width:601px) {
+  .emotion-8 {
+    width: 3rem;
+    height: 1.5rem;
+    border-radius: 0.75rem;
+  }
+}
+
+.emotion-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -848,10 +916,10 @@ exports[`<Switch /> when id, name should render correctly 1`] = `
   -ms-flex-item-align: center;
   align-self: center;
   position: absolute;
-  top: calc(0.375rem / 2);
-  width: calc(1.5rem - 0.375rem);
-  height: calc(1.5rem - 0.375rem);
   margin: 0 2px;
+  top: 3px;
+  width: 24px;
+  height: 24px;
   box-sizing: border-box;
   border: solid 1px #abb3b3;
   border-radius: 50%;
@@ -866,13 +934,21 @@ exports[`<Switch /> when id, name should render correctly 1`] = `
   transition-timing-function: cubic-bezier(0.68,1.46,0.1,1.06);
 }
 
-.emotion-2 {
+@media screen and (min-width:601px) {
+  .emotion-2 {
+    top: 3px;
+    width: 18px;
+    height: 18px;
+  }
+}
+
+.emotion-1 {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.emotion-12 {
+.emotion-7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -889,14 +965,14 @@ exports[`<Switch /> when id, name should render correctly 1`] = `
   z-index: 1;
 }
 
-.emotion-7 {
+.emotion-3 {
   vertical-align: text-bottom;
   width: 0.75rem;
   height: 0.75rem;
   fill: #fff;
 }
 
-.emotion-10 {
+.emotion-5 {
   vertical-align: text-bottom;
   width: 0.75rem;
   height: 0.75rem;
@@ -904,24 +980,24 @@ exports[`<Switch /> when id, name should render correctly 1`] = `
 }
 
 <label
-  className="emotion-16 emotion-17"
-  role="presentation"
+  className="emotion-9"
+  htmlFor="feature1-id"
 >
   <input
-    className="emotion-0 emotion-1"
+    className="emotion-0"
     id="feature1-id"
     name="feature1"
     type="checkbox"
     value={0}
   />
   <span
-    className="emotion-14 emotion-15"
+    className="fl-switch__wrapper emotion-8"
   >
     <span
-      className="emotion-4 emotion-5"
+      className="fl-switch__slider emotion-2"
     >
       <svg
-        className="emotion-2 emotion-3"
+        className="emotion-1"
         height="2"
         width="10"
         xmlns="http://www.w3.org/2000/svg"
@@ -934,10 +1010,10 @@ exports[`<Switch /> when id, name should render correctly 1`] = `
       </svg>
     </span>
     <span
-      className="emotion-12 emotion-13"
+      className="emotion-7"
     >
       <svg
-        className="emotion-6 cr-icon emotion-7 emotion-8"
+        className="cr-icon emotion-3 emotion-4"
         height="0.75rem"
         viewBox="0 0 16 16"
         width="0.75rem"
@@ -949,7 +1025,7 @@ exports[`<Switch /> when id, name should render correctly 1`] = `
         />
       </svg>
       <svg
-        className="emotion-9 cr-icon emotion-10 emotion-8"
+        className="cr-icon emotion-5 emotion-4"
         height="0.75rem"
         viewBox="0 0 16 16"
         width="0.75rem"
@@ -966,7 +1042,7 @@ exports[`<Switch /> when id, name should render correctly 1`] = `
 `;
 
 exports[`<Switch /> when passing data-props should render correctly 1`] = `
-.emotion-16 {
+.emotion-9 {
   position: relative;
   display: inline-block;
   cursor: pointer;
@@ -982,19 +1058,19 @@ exports[`<Switch /> when passing data-props should render correctly 1`] = `
   cursor: pointer;
 }
 
-.emotion-0:checked + .emotion-15 {
+.emotion-0:checked + .fl-switch__wrapper {
   background: #2875c6;
   border-color: #1d5794;
 }
 
-.emotion-0:checked + .emotion-15 .emotion-5 {
+.emotion-0:checked + .fl-switch__wrapper .fl-switch__slider {
   -webkit-transform: translateX(1.5rem);
   -ms-transform: translateX(1.5rem);
   transform: translateX(1.5rem);
   border-color: #1d5794;
 }
 
-.emotion-0:focus + .emotion-15 {
+.emotion-0:focus + .fl-switch__wrapper {
   box-shadow: 0 0 0 1pt #fff,0 0 0 3pt #2875c6;
 }
 
@@ -1002,11 +1078,13 @@ exports[`<Switch /> when passing data-props should render correctly 1`] = `
   cursor: default;
 }
 
-.emotion-0:disabled + .emotion-15 {
+.emotion-0:disabled + .fl-switch__wrapper {
   opacity: 0.5;
 }
 
-.emotion-14 {
+.emotion-8 {
+  width: 3.375rem;
+  height: 1.875rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1015,11 +1093,9 @@ exports[`<Switch /> when passing data-props should render correctly 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 3rem;
-  height: 1.5rem;
   box-sizing: border-box;
   border: solid 1px #abb3b3;
-  border-radius: 0.75rem;
+  border-radius: 1.125rem;
   background: #fff;
   -webkit-transition-property: background;
   transition-property: background;
@@ -1029,7 +1105,15 @@ exports[`<Switch /> when passing data-props should render correctly 1`] = `
   transition-timing-function: cubic-bezier(0.68,1.46,0.1,1.06);
 }
 
-.emotion-4 {
+@media screen and (min-width:601px) {
+  .emotion-8 {
+    width: 3rem;
+    height: 1.5rem;
+    border-radius: 0.75rem;
+  }
+}
+
+.emotion-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1042,10 +1126,10 @@ exports[`<Switch /> when passing data-props should render correctly 1`] = `
   -ms-flex-item-align: center;
   align-self: center;
   position: absolute;
-  top: calc(0.375rem / 2);
-  width: calc(1.5rem - 0.375rem);
-  height: calc(1.5rem - 0.375rem);
   margin: 0 2px;
+  top: 3px;
+  width: 24px;
+  height: 24px;
   box-sizing: border-box;
   border: solid 1px #abb3b3;
   border-radius: 50%;
@@ -1060,13 +1144,21 @@ exports[`<Switch /> when passing data-props should render correctly 1`] = `
   transition-timing-function: cubic-bezier(0.68,1.46,0.1,1.06);
 }
 
-.emotion-2 {
+@media screen and (min-width:601px) {
+  .emotion-2 {
+    top: 3px;
+    width: 18px;
+    height: 18px;
+  }
+}
+
+.emotion-1 {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.emotion-12 {
+.emotion-7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1083,14 +1175,14 @@ exports[`<Switch /> when passing data-props should render correctly 1`] = `
   z-index: 1;
 }
 
-.emotion-7 {
+.emotion-3 {
   vertical-align: text-bottom;
   width: 0.75rem;
   height: 0.75rem;
   fill: #fff;
 }
 
-.emotion-10 {
+.emotion-5 {
   vertical-align: text-bottom;
   width: 0.75rem;
   height: 0.75rem;
@@ -1098,23 +1190,22 @@ exports[`<Switch /> when passing data-props should render correctly 1`] = `
 }
 
 <label
-  className="emotion-16 emotion-17"
-  role="presentation"
+  className="emotion-9"
 >
   <input
-    className="emotion-0 emotion-1"
+    className="emotion-0"
     data-property1={true}
     type="checkbox"
     value={0}
   />
   <span
-    className="emotion-14 emotion-15"
+    className="fl-switch__wrapper emotion-8"
   >
     <span
-      className="emotion-4 emotion-5"
+      className="fl-switch__slider emotion-2"
     >
       <svg
-        className="emotion-2 emotion-3"
+        className="emotion-1"
         height="2"
         width="10"
         xmlns="http://www.w3.org/2000/svg"
@@ -1127,10 +1218,10 @@ exports[`<Switch /> when passing data-props should render correctly 1`] = `
       </svg>
     </span>
     <span
-      className="emotion-12 emotion-13"
+      className="emotion-7"
     >
       <svg
-        className="emotion-6 cr-icon emotion-7 emotion-8"
+        className="cr-icon emotion-3 emotion-4"
         height="0.75rem"
         viewBox="0 0 16 16"
         width="0.75rem"
@@ -1142,7 +1233,7 @@ exports[`<Switch /> when passing data-props should render correctly 1`] = `
         />
       </svg>
       <svg
-        className="emotion-9 cr-icon emotion-10 emotion-8"
+        className="cr-icon emotion-5 emotion-4"
         height="0.75rem"
         viewBox="0 0 16 16"
         width="0.75rem"

--- a/packages/flame/src/Switch/story.tsx
+++ b/packages/flame/src/Switch/story.tsx
@@ -11,6 +11,7 @@ import { Button } from '../Button';
 import { Box } from '../Core';
 
 import { SpacedGroup } from '../../../../stories/components/SpacedGroup';
+import { percyBreakpoints, percySkip } from '../../../../stories/helpers/percy';
 
 const stories = storiesOf('Switch', module).addDecorator(withReadme(Readme));
 
@@ -70,22 +71,26 @@ class SwitchWrapper extends React.Component<{}, State> {
   }
 }
 
-stories.add('States', () => (
-  <div>
-    <Heading2 mb={2}>Switch States</Heading2>
-    <Description>Toggle On / Off</Description>
-    <Box mb={3}>
-      <Switch />
-    </Box>
-    <Description>Disabled On / Off</Description>
-    <Box mb={3}>
-      <SpacedGroup>
-        <Switch disabled />
-        <Switch checked disabled />
-      </SpacedGroup>
-    </Box>
-  </div>
-));
+stories.add(
+  'States',
+  () => (
+    <div>
+      <Heading2 mb={2}>Switch States</Heading2>
+      <Description>Toggle On / Off</Description>
+      <Box mb={3}>
+        <Switch />
+      </Box>
+      <Description>Disabled On / Off</Description>
+      <Box mb={3}>
+        <SpacedGroup>
+          <Switch disabled />
+          <Switch checked disabled />
+        </SpacedGroup>
+      </Box>
+    </div>
+  ),
+  { ...percyBreakpoints },
+);
 
 // eslint-disable-next-line react/no-multi-comp
 class ToggleEventsWrapper extends React.Component<{}, { checked?: boolean }> {
@@ -144,5 +149,5 @@ stories.add(
       </Box>
     </div>
   ),
-  { percy: { skip: true } },
+  { ...percySkip },
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1000,6 +1000,18 @@
     "@emotion/sheet" "0.9.3"
     "@emotion/utils" "0.11.2"
 
+"@emotion/core@^10.0.22":
+  version "10.0.22"
+  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.22.tgz#2ac7bcf9b99a1979ab5b0a876fbf37ab0688b177"
+  integrity sha512-7eoP6KQVUyOjAkE6y4fdlxbZRA4ILs7dqkkm6oZUJmihtHv0UBq98VgPirq9T8F9K2gKu0J/au/TpKryKMinaA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@emotion/cache" "^10.0.17"
+    "@emotion/css" "^10.0.22"
+    "@emotion/serialize" "^0.11.12"
+    "@emotion/sheet" "0.9.3"
+    "@emotion/utils" "0.11.2"
+
 "@emotion/css@^10.0.14", "@emotion/css@^10.0.9":
   version "10.0.14"
   resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.14.tgz#95dacabdd0e22845d1a1b0b5968d9afa34011139"
@@ -1009,10 +1021,24 @@
     "@emotion/utils" "0.11.2"
     babel-plugin-emotion "^10.0.14"
 
+"@emotion/css@^10.0.22":
+  version "10.0.22"
+  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.22.tgz#37b1abb6826759fe8ac0af0ac0034d27de6d1793"
+  integrity sha512-8phfa5mC/OadBTmGpMpwykIVH0gFCbUoO684LUkyixPq4F1Wwri7fK5Xlm8lURNBrd2TuvTbPUGxFsGxF9UacA==
+  dependencies:
+    "@emotion/serialize" "^0.11.12"
+    "@emotion/utils" "0.11.2"
+    babel-plugin-emotion "^10.0.22"
+
 "@emotion/hash@0.7.2":
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.2.tgz#53211e564604beb9befa7a4400ebf8147473eeef"
   integrity sha512-RMtr1i6E8MXaBWwhXL3yeOU8JXRnz8GNxHvaUfVvwxokvayUY0zoBeWbKw1S9XkufmGEEdQd228pSZXFkAln8Q==
+
+"@emotion/hash@0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.3.tgz#a166882c81c0c6040975dd30df24fae8549bd96f"
+  integrity sha512-14ZVlsB9akwvydAdaEnVnvqu6J2P6ySv39hYyl/aoB6w/V+bXX0tay8cF6paqbgZsN2n5Xh15uF4pE+GvE+itw==
 
 "@emotion/hash@^0.6.2", "@emotion/hash@^0.6.6":
   version "0.6.6"
@@ -1026,10 +1052,22 @@
   dependencies:
     "@emotion/memoize" "0.7.2"
 
+"@emotion/is-prop-valid@0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.5.tgz#2dda0791f0eafa12b7a0a5b39858405cc7bde983"
+  integrity sha512-6ZODuZSFofbxSbcxwsFz+6ioPjb0ISJRRPLZ+WIbjcU2IMU0Io+RGQjjaTgOvNQl007KICBm7zXQaYQEC1r6Bg==
+  dependencies:
+    "@emotion/memoize" "0.7.3"
+
 "@emotion/memoize@0.7.2":
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.2.tgz#7f4c71b7654068dfcccad29553520f984cc66b30"
   integrity sha512-hnHhwQzvPCW1QjBWFyBtsETdllOM92BfrKWbUTmh9aeOlcVOiXvlPsK4104xH8NsaKfg86PTFsWkueQeUfMA/w==
+
+"@emotion/memoize@0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.3.tgz#5b6b1c11d6a6dddf1f2fc996f74cf3b219644d78"
+  integrity sha512-2Md9mH6mvo+ygq1trTeVp2uzAKwE2P7In0cRpD/M9Q70aH8L+rxMLbb3JCN2JoSWsV2O+DdFjfbbXoMoLBczow==
 
 "@emotion/memoize@^0.6.1", "@emotion/memoize@^0.6.6":
   version "0.6.6"
@@ -1043,6 +1081,17 @@
   dependencies:
     "@emotion/hash" "0.7.2"
     "@emotion/memoize" "0.7.2"
+    "@emotion/unitless" "0.7.4"
+    "@emotion/utils" "0.11.2"
+    csstype "^2.5.7"
+
+"@emotion/serialize@^0.11.12", "@emotion/serialize@^0.11.14":
+  version "0.11.14"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.14.tgz#56a6d8d04d837cc5b0126788b2134c51353c6488"
+  integrity sha512-6hTsySIuQTbDbv00AnUO6O6Xafdwo5GswRlMZ5hHqiFx+4pZ7uGWXUQFW46Kc2taGhP89uXMXn/lWQkdyTosPA==
+  dependencies:
+    "@emotion/hash" "0.7.3"
+    "@emotion/memoize" "0.7.3"
     "@emotion/unitless" "0.7.4"
     "@emotion/utils" "0.11.2"
     csstype "^2.5.7"
@@ -1072,13 +1121,31 @@
     "@emotion/serialize" "^0.11.10"
     "@emotion/utils" "0.11.2"
 
-"@emotion/styled@^10.0.14", "@emotion/styled@^10.0.7", "@emotion/styled@^10.0.9":
+"@emotion/styled-base@^10.0.23":
+  version "10.0.24"
+  resolved "https://registry.yarnpkg.com/@emotion/styled-base/-/styled-base-10.0.24.tgz#9497efd8902dfeddee89d24b0eeb26b0665bfe8b"
+  integrity sha512-AnBImerf0h4dGAJVo0p0VE8KoAns71F28ErGFK474zbNAHX6yqSWQUasb+1jvg/VPwZjCp19+tAr6oOB0pwmLQ==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@emotion/is-prop-valid" "0.8.5"
+    "@emotion/serialize" "^0.11.14"
+    "@emotion/utils" "0.11.2"
+
+"@emotion/styled@^10.0.14", "@emotion/styled@^10.0.7":
   version "10.0.17"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-10.0.17.tgz#0cd38b8b36259541f2c6717fc22607a120623654"
   integrity sha512-zHMgWjHDMNjD+ux64POtDnjLAObniu3znxFBLSdV/RiEhSLjHIowfvSbbd/C33/3uwtI6Uzs2KXnRZtka/PpAQ==
   dependencies:
     "@emotion/styled-base" "^10.0.17"
     babel-plugin-emotion "^10.0.17"
+
+"@emotion/styled@^10.0.23":
+  version "10.0.23"
+  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-10.0.23.tgz#2f8279bd59b99d82deade76d1046249ddfab7c1b"
+  integrity sha512-gNr04eqBQ2iYUx8wFLZDfm3N8/QUOODu/ReDXa693uyQGy2OqA+IhPJk+kA7id8aOfwAsMuvZ0pJImEXXKtaVQ==
+  dependencies:
+    "@emotion/styled-base" "^10.0.23"
+    babel-plugin-emotion "^10.0.23"
 
 "@emotion/stylis@0.8.4":
   version "0.8.4"
@@ -2777,6 +2844,13 @@
   dependencies:
     object-assign "^4.1.1"
 
+"@styled-system/core@^5.1.2":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@styled-system/core/-/core-5.1.2.tgz#b8b7b86455d5a0514f071c4fa8e434b987f6a772"
+  integrity sha512-XclBDdNIy7OPOsN4HBsawG2eiWfCcuFt6gxKn1x4QfMIgeO6TOlA2pZZ5GWZtIhCUqEPTgIBta6JXsGyCkLBYw==
+  dependencies:
+    object-assign "^4.1.1"
+
 "@styled-system/css@^5.0.23":
   version "5.0.23"
   resolved "https://registry.yarnpkg.com/@styled-system/css/-/css-5.0.23.tgz#35ad4f34fe0fec9b011a5468ac0821f12f5e4b1a"
@@ -2830,6 +2904,13 @@
   integrity sha512-LxIuubZZ65HzTWsl9GpfDXWaYdkcOsEKSBwNdeg4S3TgszPheN5f++eLxyDun3is2dNhFjTbDL/7yBZwJo1h3g==
   dependencies:
     "@styled-system/core" "^5.0.16"
+
+"@styled-system/theme-get@5.1.2":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@styled-system/theme-get/-/theme-get-5.1.2.tgz#b40a00a44da63b7a6ed85f73f737c4defecd6049"
+  integrity sha512-afAYdRqrKfNIbVgmn/2Qet1HabxmpRnzhFwttbGr6F/mJ4RDS/Cmn+KHwHvNXangQsWw/5TfjpWV+rgcqqIcJQ==
+  dependencies:
+    "@styled-system/core" "^5.1.2"
 
 "@styled-system/typography@^5.1.1":
   version "5.1.1"
@@ -3217,6 +3298,20 @@
   integrity sha512-RAF9Erif51vbD1ZbIiGN4ZrgxpSr44iMXrPjQK5+tI7PWLDugKepTWj7T/LqG5VfaYYIrEmOCzIpulhv+/D/XQ==
   dependencies:
     csstype "^2.6.4"
+
+"@types/styled-system@^5.1.4":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@types/styled-system/-/styled-system-5.1.4.tgz#c273b1ebb9b26cb1bd9282c994fc56c82d0fbfaf"
+  integrity sha512-iBtFFmlxBbiTMpoKvRupwg75PeVbf7BBsgTlpcVBBbZyUKrhuU/4jtJQUn/wsSndKfxW0U9T17Geq0GGFWkCZw==
+  dependencies:
+    csstype "^2.6.4"
+
+"@types/styled-system__css@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/styled-system__css/-/styled-system__css-5.0.4.tgz#df83b015cf377ab39ecf33ea31339c05eeb9230a"
+  integrity sha512-SHHoNh9cCRTG9hcmCD2ua0NeYUrLmLXoMJ7g0U/e0FjrzcwNQtM5wjjEJVCVZymU632xA1PdPEykrtoSHTIecA==
+  dependencies:
+    csstype "^2.6.6"
 
 "@types/webpack-env@*":
   version "1.14.0"
@@ -4303,6 +4398,22 @@ babel-plugin-emotion@^10.0.0, babel-plugin-emotion@^10.0.14, babel-plugin-emotio
     "@emotion/hash" "0.7.2"
     "@emotion/memoize" "0.7.2"
     "@emotion/serialize" "^0.11.10"
+    babel-plugin-macros "^2.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^1.0.5"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+
+babel-plugin-emotion@^10.0.22, babel-plugin-emotion@^10.0.23:
+  version "10.0.23"
+  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.0.23.tgz#040d40bf61dcab6d31dd6043d10e180240b8515b"
+  integrity sha512-1JiCyXU0t5S2xCbItejCduLGGcKmF3POT0Ujbexog2MI4IlRcIn/kWjkYwCUZlxpON0O5FC635yPl/3slr7cKQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@emotion/hash" "0.7.3"
+    "@emotion/memoize" "0.7.3"
+    "@emotion/serialize" "^0.11.14"
     babel-plugin-macros "^2.0.0"
     babel-plugin-syntax-jsx "^6.18.0"
     convert-source-map "^1.5.0"
@@ -6733,6 +6844,11 @@ csstype@^2.2.0, csstype@^2.5.2, csstype@^2.5.7, csstype@^2.6.4:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.6.tgz#c34f8226a94bbb10c32cc0d714afdf942291fc41"
   integrity sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==
+
+csstype@^2.6.6:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.7.tgz#20b0024c20b6718f4eda3853a1f5a1cce7f5e4a5"
+  integrity sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
## Description

Switch will now properly resize on mobile devices.

I've also taken the time to leverage `emotion`'s css props and `styled-system/css` to create these styles. This should lead into a somewhat more maintainable codebase, as well as reduce the unnecessary HOC wrapping caused by `emotion/styled`


<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->
<!-- Closes #XXX -->

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [x] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [x] I have added tests that prove my fix is effective or that my feature works
