### PR TITLE
Remove FlameFonts from install docs, mark as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,23 +55,6 @@ Add this `<link>` tag to your `<head>` to load the required fonts:
 />
 ```
 
-Alternatively, if you use `React Helmet` or can render to the `<head>` tag in JavaScript, you may use the provided `FlameFonts` component:
-
-```jsx
-import { Helmet } from 'react-helmet';
-import { FlameFonts } from '@lightspeed/flame/Core';
-
-// ..
-render() {
-  return (
-    <Helmet>
-      <title>My Title</title>
-      <FlameFonts />
-    </Helmet>
-  );
-}
-```
-
 ### Hook the theme provider, load global styles, and import components
 
 In order to have the proper styling, it is necessary to load the theme object into the application.

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -11,7 +11,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ### Deprecated
 
-- FlameTheme component will be removed from the next major version of Flame, use [link](https://github.com/lightspeed/flame#link-fonts) instead
+- FlameTheme component will be removed from the next major version of Flame, use [link](https://github.com/lightspeed/flame#link-fonts) instead ([#50](https://github.com/lightspeed/flame/pull/50))
 
 ## 1.2.3 - 2019-11-22
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Deprecated
+
+- FlameTheme component will be removed from the next major version of Flame, use [link](https://github.com/lightspeed/flame#link-fonts) instead
+
 ## 1.2.3 - 2019-11-22
 
 ### Fixed

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -11,7 +11,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ### Deprecated
 
-- FlameTheme component will be removed from the next major version of Flame, use [link](https://github.com/lightspeed/flame#link-fonts) instead ([#50](https://github.com/lightspeed/flame/pull/50))
+- FlameFonts component will be removed from the next major version of Flame, use [link](https://github.com/lightspeed/flame#link-fonts) instead ([#50](https://github.com/lightspeed/flame/pull/50))
 
 ## 1.2.3 - 2019-11-22
 

--- a/packages/flame/src/Core/index.tsx
+++ b/packages/flame/src/Core/index.tsx
@@ -106,6 +106,8 @@ const FlameTheme: React.FunctionComponent<FlameThemeProps> = ({
   return <ThemeProvider theme={{ ...selectedTheme, ...themeOverrides }}>{children}</ThemeProvider>;
 };
 
+// TODO: Will be deprecated in v2, instead, use the link tag directly:
+// https://github.com/lightspeed/flame#link-fonts
 const FlameFonts: React.FunctionComponent = () => (
   <link
     href="https://fonts.googleapis.com/css?family=Lato:400,700&subset=latin-ext"

--- a/packages/flame/src/Core/index.tsx
+++ b/packages/flame/src/Core/index.tsx
@@ -106,7 +106,8 @@ const FlameTheme: React.FunctionComponent<FlameThemeProps> = ({
   return <ThemeProvider theme={{ ...selectedTheme, ...themeOverrides }}>{children}</ThemeProvider>;
 };
 
-// TODO: Will be deprecated in v2, instead, use the link tag directly:
+// WARNING!
+// This component will be deprecated in v2. Instead, use the link tag directly:
 // https://github.com/lightspeed/flame#link-fonts
 const FlameFonts: React.FunctionComponent = () => (
   <link


### PR DESCRIPTION
## Description

Read why in https://github.com/lightspeed/flame/issues/49.

<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->
<!-- Closes #XXX -->

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [ ] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [ ] I have added tests that prove my fix is effective or that my feature works
