### PR TITLE
Improve contributing guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,5 +1,17 @@
 # Contributing
 
+Lightspeed Flame is a project that is actively used and maintained to build Lightspeed products internally. It's being treated the same way as any internal development work and follows our product roadmap as with any features built within Lightspeed.
+
+The main purpose of working on it open-source is to be transparent on what we bring to our customers, but also to be able to get valuable feedback and contribution from the community. We believe open-source is vital to software development as most of the libraries we rely on are built in the open space.
+
+As our journey begins in the open-source world, we are accepting [bug reports](https://github.com/lightspeed/flame/issues/new?template=BUG_REPORT.md), [feature request](https://github.com/lightspeed/flame/issues/new?template=FEATURE_REQUEST.md) as well as pull requests for improvements, but no additions or breaking changes until we have a proper process to accept and treat those accordingly.
+
+We still encourage anyone to fork and play around Flame for personal usage. Read our [LICENSE](../LICENSE) in case of uncertainty on what we allow in this regard.
+
+Thanks in advance for any contribution made to Flame and we look forward to hear from you!
+
+## Code of conduct
+
 By contributing to Flame, you agree to abide by the [code of conduct](/.github/CODE_OF_CONDUCT.md).
 
 ## Development
@@ -15,45 +27,50 @@ git clone git@github.com:lightspeed/flame.git
 To create a brand new component, use the following command that will create a base skeleton ready for development:
 
 ```sh
-yarn generate Component
+yarn generate
 ```
 
-Where `Component` is the name of the component you want to create. This will create the base component structure and story for development/documentation in `packages/flame-{component-name}`, which are considered [add-ons / experimental](https://github.com/lightspeed/flame#add-ons-and-experimental-components) until being deemed ready to go into the [mainline package](https://github.com/lightspeed/flame/tree/master/packages/flame).
+You will be given a choice of "Mainline" or "Add-on" component, then have to choose a name for the component.
+
+#### Mainline component
+
+Mainline components will be created under `packages/flame/src/{ComponentName}`, where all other components are located. This will create the base component structure ready for development, including README for docs, story for Storybook development and visual regression test, tests and TypeScript component file.
+
+#### Add-on component
+
+Add-on component will be created under the `packages/flame-{component-name}`. It should be used for add-on/experimental components that are not ready to go into the [mainline package](https://github.com/lightspeed/flame/tree/master/packages/flame) or are considered as "extras" and don't fit our component library.
+
+Add-on components are a completely separate package with their own version and have `@lightspeed/flame` and all its required dependencies as `peerDependencies`. They include the same base component structure as a mainline component, but also have a `tsconfig` to output types as well as their own LICENSE and CHANGELOG files.
 
 ### Commands
 
 Each commands below must be run at the root of the project.
 
-#### Handling package dependencies
-
-All commands that affect packages will need to be handled using `yarn workspace <pkg name> <command>` command, example:
-
-```sh
-yarn workspace @lightspeed/flame-<package> add left-pad
-```
-
 #### Bootstrap the application
 
-Before starting development, you'll need to bootstrap the component library. This phase will generate the needed files for themes, icons and so on.
-
-To bootstrap, run the following command:
+First, install dependencies:
 
 ```sh
-yarn bootstrap # Make sure you've ran `yarn install` first to have up-to-date dependencies
+yarn install
 ```
 
-The bootstrapping phase is only required when starting on a fresh development, or when working on packages that generate files at build time. This is because this step is usually quite long and only needs to be done once in a while.
+Before starting development, you'll need to bootstrap the component library. This phase will generate the necessary files for theming, icons and so on:
+
+```sh
+yarn bootstrap
+```
+
+The bootstrapping phase is only required when starting on a fresh install, or when working on packages that generate files at build time. This is because this step is usually quite long and only needs to be done once in a while.
 
 #### Launch Storybook for local development
 
-We use [Storybook](https://storybook.js.org/) as developing environment for our components.
-To begin development, run:
+We use [Storybook](https://storybook.js.org/) as developing environment for our components. To begin development, run:
 
 ```sh
 yarn dev
 ```
 
-This will install dependencies, including `packages/` ones, and launch Storybook on [http://localhost:6006/](http://localhost:6006/).
+This will install/update dependencies, including `packages/` ones, and launch Storybook on [http://localhost:6006/](http://localhost:6006/).
 
 #### Run tests
 
@@ -81,10 +98,10 @@ yarn typecheck
 
 ## Git workflow
 
-1. Create a feature branch from `master` describing the change (`fix-button-space` for example)
+1. Create a feature branch from `master` (or from a fork if from an external contribution) describing the change (`fix-button-space` for example)
 2. When done, push your branch to origin and open a Pull Request with the change in the subject (`Fix Button space` for example)
 3. Fill in the required information from the Pull Request template
-4. Update `CHANGELOG` based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) by adding a `[Unreleased]` section for the changed package(s), for example:
+4. Update `CHANGELOG` based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) by adding a `[Unreleased]` section for the changed package(s). This will allow us to know which type of version bump will be needed once the change is merged and we initiate a [release](../RELEASE.md). For example:
 
 ```md
 ## [Unreleased]
@@ -94,7 +111,7 @@ yarn typecheck
 - Fix space ([#520](https://github.com/lightspeed/flame/pull/520))
 ```
 
-Here's a list of type of changes (for the `###` titles):
+Here's a list of group sections we support for categorization:
 
 - **Added** for new features.
 - **Changed** for changes in existing functionality.
@@ -109,9 +126,7 @@ Here's a list of type of changes (for the `###` titles):
 
 ### Why does running the dev command throw errors when I just pulled the repo or on switching branches?
 
-There's a good chance that some files were not auto-generated. Try bootstraping before starting development.
-
-To do so, run the following command:
+There's a good chance that some files were not auto-generated. Try bootstraping before starting development. To do so, run the following command:
 
 ```sh
 yarn bootstrap

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,9 +4,9 @@ Lightspeed Flame is a project that is actively used and maintained to build Ligh
 
 The main purpose of working on it open-source is to be transparent on what we bring to our customers, but also to be able to get valuable feedback and contribution from the community. We believe open-source is vital to software development as most of the libraries we rely on are built in the open space.
 
-As our journey begins in the open-source world, we are accepting [bug reports](https://github.com/lightspeed/flame/issues/new?template=BUG_REPORT.md), [feature request](https://github.com/lightspeed/flame/issues/new?template=FEATURE_REQUEST.md) as well as pull requests for improvements, but no additions or breaking changes until we have a proper process to accept and treat those accordingly.
+As our journey begins in the open-source world, we are accepting [bug reports](https://github.com/lightspeed/flame/issues/new?template=BUG_REPORT.md), [feature requests](https://github.com/lightspeed/flame/issues/new?template=FEATURE_REQUEST.md) and pull requests for improvements. We are not accepting additions or breaking changes until we have a proper process to triage and approve these changes accordingly.
 
-We still encourage anyone to fork and play around Flame for personal usage. Read our [LICENSE](../LICENSE) in case of uncertainty on what we allow in this regard.
+We still encourage anyone to fork and play around Flame for personal usage. Read our [LICENSE](../LICENSE) in the case of commercial use.
 
 Thanks in advance for any contribution made to Flame and we look forward to hear from you!
 
@@ -34,7 +34,7 @@ You will be given a choice of "Mainline" or "Add-on" component, then have to cho
 
 #### Mainline component
 
-Mainline components will be created under `packages/flame/src/{ComponentName}`, where all other components are located. This will create the base component structure ready for development, including README for docs, story for Storybook development and visual regression test, tests and TypeScript component file.
+Mainline components will be created under `packages/flame/src/{ComponentName}`, where all other components are located. The base component structure includes a Storybook file, a test file and a component file.
 
 #### Add-on component
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,7 @@
 # Release workflow
 
+We follow [semver (Semantic Versioning)](https://semver.org/) for Flame releases. Releases are handled by Flame maintainers manually when changes merged to `master` are deemed ready for publishing.
+
 ## Versioning and publishing
 
 1. Make sure your local `master` branch is up to date including tags

--- a/packages/flame-tokens/story.tsx
+++ b/packages/flame-tokens/story.tsx
@@ -14,7 +14,7 @@ import { hex2rgba } from '../../stories/helpers/color';
 import { remToPxFromString } from '../../stories/helpers/unit';
 import { Grid } from '../../stories/components/grid';
 
-const stories = storiesOf('tokens', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Theme|Tokens', module).addDecorator(withReadme(Readme));
 
 const { typeface, weights, fontSizes, letterSpacings } = typography;
 const { scale } = spacing;

--- a/packages/flame/src/Alert/story.tsx
+++ b/packages/flame/src/Alert/story.tsx
@@ -7,7 +7,7 @@ import { Text } from '../Text';
 import { IconWarning } from '../Icon/Warning';
 import Readme from './README.md';
 
-const stories = storiesOf('Alert', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Alert', module).addDecorator(withReadme(Readme));
 
 stories.add('Story', () => {
   const alerts = ['info', 'warning', 'success', 'danger'].map(type => {

--- a/packages/flame/src/Autocomplete/story.tsx
+++ b/packages/flame/src/Autocomplete/story.tsx
@@ -9,7 +9,7 @@ import Readme from './README.md';
 import { Box } from '../Core';
 import { Text } from '../Text';
 
-const stories = storiesOf('Autocomplete', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Autocomplete', module).addDecorator(withReadme(Readme));
 
 function onCreateOption(value: any, currentItems: any) {
   const newOption = {

--- a/packages/flame/src/Badge/story.tsx
+++ b/packages/flame/src/Badge/story.tsx
@@ -5,7 +5,7 @@ import { withReadme } from 'storybook-readme';
 import { Badge, PillBadge, BadgeTypes } from './Badge';
 import Readme from './README.md';
 
-const stories = storiesOf('Badge', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Badge', module).addDecorator(withReadme(Readme));
 
 const statuses: BadgeTypes[] = ['success', 'danger', 'info', 'important', 'warning', 'default'];
 

--- a/packages/flame/src/Bone/story.tsx
+++ b/packages/flame/src/Bone/story.tsx
@@ -9,7 +9,7 @@ import Readme from './README.md';
 import { Card, CardSection } from '../Card';
 import { Divider } from '../Divider';
 
-const stories = storiesOf('Bone', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Bone', module).addDecorator(withReadme(Readme));
 
 stories.add('Styles', () => (
   <div>

--- a/packages/flame/src/Button/story.tsx
+++ b/packages/flame/src/Button/story.tsx
@@ -12,7 +12,7 @@ import { Icon } from '../Icon';
 
 import { SpacedGroup } from '../../../../stories/components/SpacedGroup';
 
-const stories = storiesOf('Button', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Button', module).addDecorator(withReadme(Readme));
 
 type ButtonPresenterState = {
   isDisabled?: boolean;

--- a/packages/flame/src/Card/story.tsx
+++ b/packages/flame/src/Card/story.tsx
@@ -10,7 +10,7 @@ import { Box } from '../Core';
 
 import Readme from './README.md';
 
-const stories = storiesOf('Card', module)
+const stories = storiesOf('Components|Card', module)
   .addDecorator(withReadme(Readme))
   .addDecorator(storyFn => {
     return <React.Fragment>{storyFn()}</React.Fragment>;

--- a/packages/flame/src/Checkbox/story.tsx
+++ b/packages/flame/src/Checkbox/story.tsx
@@ -9,7 +9,7 @@ import { Box } from '../Core';
 import { Checkbox } from './Checkbox';
 import Readme from './README.md';
 
-const stories = storiesOf('Checkbox', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Checkbox', module).addDecorator(withReadme(Readme));
 
 const noop = () => {};
 

--- a/packages/flame/src/Dialog/story.tsx
+++ b/packages/flame/src/Dialog/story.tsx
@@ -9,7 +9,7 @@ import Readme from './README.md';
 
 const title = 'Dialog Prompt';
 const message = `It seems you're about to do this action. It might be destructive or not, but anyways, a heads up about what's going to happen. Are you really sure you want to proceed?`;
-const stories = storiesOf('Dialog', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Dialog', module).addDecorator(withReadme(Readme));
 
 const delay = (milliseconds: number) => (result?: any) =>
   new Promise(resolve => {

--- a/packages/flame/src/Divider/story.tsx
+++ b/packages/flame/src/Divider/story.tsx
@@ -9,7 +9,7 @@ import { Divider } from './Divider';
 
 import Readme from './README.md';
 
-const stories = storiesOf('Divider', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Divider', module).addDecorator(withReadme(Readme));
 const cardsStyles = { maxWidth: '640px' };
 const cardsContent = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.';
 

--- a/packages/flame/src/Dropdown/story.tsx
+++ b/packages/flame/src/Dropdown/story.tsx
@@ -12,7 +12,7 @@ import { Button } from '../Button';
 import { Select } from '../Select';
 import { Heading3, TextLink } from '../Text';
 
-const stories = storiesOf('Dropdown', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Dropdown', module).addDecorator(withReadme(Readme));
 
 const SampleDropdownContent = () => (
   <DropdownContent width="100px">

--- a/packages/flame/src/Flag/examples/story.tsx
+++ b/packages/flame/src/Flag/examples/story.tsx
@@ -21,7 +21,7 @@ import { Text } from '../../Text';
 import { Ul } from '../../../../../stories/components/Ul';
 import { SpacedGroup } from '../../../../../stories/components/SpacedGroup';
 
-const stories = storiesOf('Flag', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Flag', module).addDecorator(withReadme(Readme));
 
 const Description: React.FC = ({ children }) => (
   <Text fontSize="text-s" mb={1}>

--- a/packages/flame/src/FormField/story.tsx
+++ b/packages/flame/src/FormField/story.tsx
@@ -7,7 +7,7 @@ import { Heading3, Text } from '../Text';
 import { Autocomplete } from '../Autocomplete';
 import { Label } from './FormField';
 
-const stories = storiesOf('FormField', module);
+const stories = storiesOf('Components|FormField', module);
 
 const exampleItems = [
   { value: '1', label: 'Red' },

--- a/packages/flame/src/Group/story.tsx
+++ b/packages/flame/src/Group/story.tsx
@@ -12,7 +12,7 @@ import { Icon } from '../Icon';
 import { Text } from '../Text';
 import { Badge, PillBadge } from '../Badge';
 
-const stories = storiesOf('Group', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Group', module).addDecorator(withReadme(Readme));
 
 const Description: React.FC = ({ children }) => (
   <Text fontSize="text-s" mb={1}>

--- a/packages/flame/src/Icon/examples/story.tsx
+++ b/packages/flame/src/Icon/examples/story.tsx
@@ -16,7 +16,7 @@ import IconList from '../../../svg/Icon.list.json';
 import '../../../svg/Icons/icon.scss';
 import { Ul } from '../../../../../stories/components/Ul';
 
-const stories = storiesOf('Icon', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Icon', module).addDecorator(withReadme(Readme));
 
 const iconList: any = IconList;
 

--- a/packages/flame/src/Input/story.tsx
+++ b/packages/flame/src/Input/story.tsx
@@ -10,7 +10,7 @@ import { Badge } from '../Badge';
 import { Button } from '../Button';
 import { Icon } from '../Icon';
 
-const stories = storiesOf('Input', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Input', module).addDecorator(withReadme(Readme));
 
 const firstArgAction = decorateAction([(args: any) => [args[0].target.value]]);
 

--- a/packages/flame/src/InputGroup/story.tsx
+++ b/packages/flame/src/InputGroup/story.tsx
@@ -28,7 +28,7 @@ const SampleDropdownContent = () => (
   </DropdownContent>
 );
 
-const stories = storiesOf('InputGroup', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|InputGroup', module).addDecorator(withReadme(Readme));
 
 stories.add('Story', () => (
   <div>

--- a/packages/flame/src/Layout/examples/story.tsx
+++ b/packages/flame/src/Layout/examples/story.tsx
@@ -10,7 +10,7 @@ import { Box, Flex } from '../../Core';
 import { Button } from '../../Button';
 import { Text } from '../../Text';
 
-const stories = storiesOf('Layout', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Layout', module).addDecorator(withReadme(Readme));
 
 const FakeContent = () => (
   <React.Fragment>

--- a/packages/flame/src/Modal/story.tsx
+++ b/packages/flame/src/Modal/story.tsx
@@ -10,7 +10,7 @@ import { ModalFooter } from './ModalFooter';
 import { Button } from '../Button';
 import Readme from './README.md';
 
-const stories = storiesOf('Modal', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Modal', module).addDecorator(withReadme(Readme));
 
 type Props = {
   header?: boolean;

--- a/packages/flame/src/Popover/story.tsx
+++ b/packages/flame/src/Popover/story.tsx
@@ -12,7 +12,7 @@ import { Box } from '../Core';
 import Readme from './README.md';
 import styles from '../../../../stories/styles/stories.scss';
 
-const stories = storiesOf('Popover', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Popover', module).addDecorator(withReadme(Readme));
 
 const placements: PopoverPlacement[] = [
   'top-start',

--- a/packages/flame/src/Progress/story.tsx
+++ b/packages/flame/src/Progress/story.tsx
@@ -10,7 +10,7 @@ import { Heading2, Heading3, TextContent } from '../Text';
 import { Box } from '../Core';
 import Readme from './README.md';
 
-const stories = storiesOf('Progress', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Progress', module).addDecorator(withReadme(Readme));
 
 stories.add('Linear', () => (
   <TextContent>

--- a/packages/flame/src/Radio/story.tsx
+++ b/packages/flame/src/Radio/story.tsx
@@ -10,7 +10,7 @@ import { Box } from '../Core';
 
 import Readme from './README.md';
 
-const stories = storiesOf('Radio', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Radio', module).addDecorator(withReadme(Readme));
 
 stories.add('Story', () => (
   <div>

--- a/packages/flame/src/Select/story.tsx
+++ b/packages/flame/src/Select/story.tsx
@@ -8,7 +8,7 @@ import { Box } from '../Core';
 import SelectExample from './examples';
 import Readme from './README.md';
 
-const stories = storiesOf('Select', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Select', module).addDecorator(withReadme(Readme));
 
 stories.add('Story', () => (
   <TextContent>

--- a/packages/flame/src/Spinner/story.tsx
+++ b/packages/flame/src/Spinner/story.tsx
@@ -9,7 +9,7 @@ import { Text } from '../Text';
 
 import { SpacedGroup } from '../../../../stories/components/SpacedGroup';
 
-const stories = storiesOf('Spinner', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Spinner', module).addDecorator(withReadme(Readme));
 
 stories.add('Story', () => (
   <div>

--- a/packages/flame/src/Switch/story.tsx
+++ b/packages/flame/src/Switch/story.tsx
@@ -12,7 +12,7 @@ import { Box } from '../Core';
 
 import { SpacedGroup } from '../../../../stories/components/SpacedGroup';
 
-const stories = storiesOf('Switch', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Switch', module).addDecorator(withReadme(Readme));
 
 const Description: React.FC = ({ children }) => (
   <Text fontSize="text-s" mb={1}>

--- a/packages/flame/src/Tab/story.tsx
+++ b/packages/flame/src/Tab/story.tsx
@@ -6,7 +6,7 @@ import Readme from './README.md';
 import { Tab, TabContainer } from './Tab';
 import { Card, CardSection } from '../Card';
 
-const stories = storiesOf('Tab', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Tab', module).addDecorator(withReadme(Readme));
 
 const StoryTab = () => {
   const [state, setState] = React.useState(0);

--- a/packages/flame/src/Tag/story.tsx
+++ b/packages/flame/src/Tag/story.tsx
@@ -10,7 +10,7 @@ import { Text, TextContent, Heading2, Heading3 } from '../Text';
 import TagList from './examples/TagList';
 import { Icon } from '../Icon';
 
-const stories = storiesOf('Tag', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Tag', module).addDecorator(withReadme(Readme));
 
 stories.add('Types', () => (
   <TextContent>

--- a/packages/flame/src/Text/story.tsx
+++ b/packages/flame/src/Text/story.tsx
@@ -7,7 +7,7 @@ import { Divider } from '../Divider';
 import { Box } from '../Core';
 import Readme from './README.md';
 
-const stories = storiesOf('Text', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Text', module).addDecorator(withReadme(Readme));
 
 const textBodyStyles: ('small' | 'normal' | 'large' | 'xlarge')[] = [
   'small',

--- a/packages/flame/src/Tooltip/story.tsx
+++ b/packages/flame/src/Tooltip/story.tsx
@@ -8,7 +8,7 @@ import { Input } from '../Input';
 import Readme from './README.md';
 import styles from '../../../../stories/styles/stories.scss';
 
-const stories = storiesOf('Tooltip', module).addDecorator(withReadme(Readme));
+const stories = storiesOf('Components|Tooltip', module).addDecorator(withReadme(Readme));
 
 const placements: TooltipPlacement[] = [
   'top',

--- a/plopfile.js
+++ b/plopfile.js
@@ -1,5 +1,17 @@
 /* eslint-disable no-console */
-const addToFolder = (filename, { path = '', preset = 'addon' } = {}) => {
+const addToComponent = (filename, { path = '' } = {}) => {
+  const componentName = '{{pascalCase name}}';
+  const templatePath = path.replace('{{kebabCase name}}', 'name');
+  const nextFilename = filename.replace('Component', '{{pascalCase name}}');
+
+  return {
+    type: 'add',
+    path: `packages/flame/src/${componentName}/${path}${nextFilename}`,
+    templateFile: `scripts/plop/templates/component/${templatePath}${filename}.hbs`,
+  };
+};
+
+const addToAddon = (filename, { path = '' } = {}) => {
   const packageName = 'flame-{{kebabCase name}}';
   const templatePath = path.replace('{{kebabCase name}}', 'name');
   const nextFilename = filename.replace('Component', '{{pascalCase name}}');
@@ -7,11 +19,9 @@ const addToFolder = (filename, { path = '', preset = 'addon' } = {}) => {
   return {
     type: 'add',
     path: `packages/${packageName}/${path}${nextFilename}`,
-    templateFile: `scripts/plop/templates/${preset}/${templatePath}${filename}.hbs`,
+    templateFile: `scripts/plop/templates/addon/${templatePath}${filename}.hbs`,
   };
 };
-
-const addToAddon = (filename, config = {}) => addToFolder(filename, { ...config });
 
 const exitMessage = answers => {
   const { name } = answers;
@@ -29,8 +39,28 @@ module.exports = plop => {
 
   plop.addHelper('currentYear', () => new Date().getFullYear());
 
+  plop.setGenerator('Mainline component', {
+    description: 'Create a new mainline component',
+    prompts: [
+      {
+        type: 'input',
+        name: 'name',
+        message: 'Enter component name',
+        default: 'Component',
+      },
+    ],
+    actions: [
+      addToComponent('Component.test.tsx', { path: '__tests__/' }),
+      addToComponent('Component.tsx'),
+      addToComponent('index.tsx'),
+      addToComponent('README.md'),
+      addToComponent('story.tsx'),
+      { type: 'exitMessage' },
+    ],
+  });
+
   plop.setGenerator('Add-on component', {
-    description: 'Create a new add-on component',
+    description: 'Create a new add-on/experimentall component',
     prompts: [
       {
         type: 'input',

--- a/plopfile.js
+++ b/plopfile.js
@@ -60,7 +60,7 @@ module.exports = plop => {
   });
 
   plop.setGenerator('Add-on component', {
-    description: 'Create a new add-on/experimentall component',
+    description: 'Create a new add-on/experimental component',
     prompts: [
       {
         type: 'input',

--- a/scripts/plop/templates/addon/story.tsx.hbs
+++ b/scripts/plop/templates/addon/story.tsx.hbs
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 
 import { {{pascalCase name}} } from './src';
 
-const stories = storiesOf('{{pascalCase name}}', module);
+const stories = storiesOf('Add-ons|{{pascalCase name}}', module);
 
 stories.add('Story', () => (
   <div>

--- a/scripts/plop/templates/component/Component.tsx.hbs
+++ b/scripts/plop/templates/component/Component.tsx.hbs
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+export interface {{pascalCase name}}Props {}
+
+const {{pascalCase name}}: React.FC<{{pascalCase name}}Props> = ({ children }) => <div>{children}</div>;
+
+export { {{pascalCase name}} };

--- a/scripts/plop/templates/component/README.md.hbs
+++ b/scripts/plop/templates/component/README.md.hbs
@@ -1,0 +1,31 @@
+# {{pascalCase name}}
+
+{{pascalCase name}} component description.
+
+## Usage
+
+First, make sure you have been through the [Getting started](https://github.com/lightspeed/flame#getting-started) steps of adding Flame in your application.
+
+### React Component
+
+#### Props
+
+| Prop       | Type            | Description                              |
+| ---------- | --------------- | ---------------------------------------- |
+| `children` | React.ReactNode | The content to display inside the button |
+| `prop`     | PropType        | Prop description                         |
+
+#### Example
+
+```js
+import React from 'react';
+import { {{pascalCase name }} } from '@lightspeed/flame/{{pascalCase name }}';
+
+const MyComponent = () => (
+  <div>
+    <{{pascalCase name }} />
+  </div>
+);
+
+export default MyComponent;
+```

--- a/scripts/plop/templates/component/__tests__/Component.test.tsx.hbs
+++ b/scripts/plop/templates/component/__tests__/Component.test.tsx.hbs
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+import { customRender } from 'test-utils';
+
+import { {{pascalCase name}} } from '../{{pascalCase name}}';
+
+describe('{{pascalCase name}}', () => {
+  it('should be tested', () => {
+    const { container } = customRender(<{{pascalCase name}}>children</{{pascalCase name}}>);
+    expect(container).toBeDefined();
+  });
+});

--- a/scripts/plop/templates/component/__tests__/Component.test.tsx.hbs
+++ b/scripts/plop/templates/component/__tests__/Component.test.tsx.hbs
@@ -7,6 +7,7 @@ import { {{pascalCase name}} } from '../{{pascalCase name}}';
 describe('{{pascalCase name}}', () => {
   it('should be tested', () => {
     const { container } = customRender(<{{pascalCase name}}>children</{{pascalCase name}}>);
-    expect(container).toBeDefined();
+    // This will fail on purpose
+    expect(container).toHaveTextContent('my component');
   });
 });

--- a/scripts/plop/templates/component/index.tsx.hbs
+++ b/scripts/plop/templates/component/index.tsx.hbs
@@ -1,0 +1,3 @@
+import { {{pascalCase name}}, {{pascalCase name}}Props } from './{{pascalCase name}}';
+
+export { {{pascalCase name}}, {{pascalCase name}}Props };

--- a/scripts/plop/templates/component/story.tsx.hbs
+++ b/scripts/plop/templates/component/story.tsx.hbs
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 
 import { {{pascalCase name}} } from './{{pascalCase name}}';
 
-const stories = storiesOf('{{pascalCase name}}', module);
+const stories = storiesOf('Components|{{pascalCase name}}', module);
 
 stories.add('Story', () => (
   <div>

--- a/scripts/plop/templates/component/story.tsx.hbs
+++ b/scripts/plop/templates/component/story.tsx.hbs
@@ -1,0 +1,12 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { {{pascalCase name}} } from './{{pascalCase name}}';
+
+const stories = storiesOf('{{pascalCase name}}', module);
+
+stories.add('Story', () => (
+  <div>
+    <{{pascalCase name}}>{{pascalCase name}} Story</{{pascalCase name}}>
+  </div>
+));


### PR DESCRIPTION
## Description

Our contributing guide needed a bit of ❤️, especially for external contributors. I've also added a `yarn generate` command for mainline components.

<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->
<!-- Closes #XXX -->

## How to test?

See changed files for the contributing guide updates.

For the new generate script:

- Pull branch
- Run `yarn generate`
- Choose "Mainline component"
- Choose a name or use the default one ("Component")
- Run `yarn dev`
- You should see the newly generated component story within Storybook

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [ ] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [ ] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [ ] I have added tests that prove my fix is effective or that my feature works
