### PR TITLE
Use official Percy GitHub Action for visual regression snapshots

### DIFF
--- a/.github/workflows/percy-snapshot.yml
+++ b/.github/workflows/percy-snapshot.yml
@@ -10,27 +10,29 @@ jobs:
     name: Run visual regression tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Dump GitHub context
-      run: echo "$GITHUB_CONTEXT"
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-    - name: Read .nvmrc
-      run: echo ::set-output name=nvmrc::$(cat .nvmrc)
-      id: nvm
-    - name: Setup node
-      uses: actions/setup-node@v1.1.1
-      with:
-        node-version: '${{ steps.nvm.outputs.nvmrc }}'
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/yarn
-        key: ${{ runner.OS }}-yarn-cache-v1-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-cache-v1-
-    - name: Install
-      run: yarn install --frozen-lockfile && yarn bootstrap
-    - name: Snapshot
-      run: yarn percy
-      env:
-        PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+      - uses: actions/checkout@master
+      - name: Dump GitHub context
+        run: echo "$GITHUB_CONTEXT"
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+      - name: Read .nvmrc
+        run: echo ::set-output name=nvmrc::$(cat .nvmrc)
+        id: nvm
+      - name: Setup node
+        uses: actions/setup-node@v1.1.1
+        with:
+          node-version: '${{ steps.nvm.outputs.nvmrc }}'
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/yarn
+          key: ${{ runner.OS }}-yarn-cache-v1-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-cache-v1-
+      - name: Install
+        run: yarn install --frozen-lockfile && yarn bootstrap
+      - name: Percy
+        uses: percy/storybook-action@v0.1.2
+        with:
+          custom-command: 'yarn storybook:percy'
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.github/workflows/percy-snapshot.yml
+++ b/.github/workflows/percy-snapshot.yml
@@ -33,6 +33,6 @@ jobs:
       - name: Percy
         uses: percy/storybook-action@v0.1.2
         with:
-          custom-command: 'yarn storybook:percy'
+          custom-command: 'yarn percy'
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}


### PR DESCRIPTION
## Description

See https://docs.percy.io/docs/github-actions. For some reason snapshots on `master` are detected as `HEAD`, thus won't get auto-approved. Let's see if using the official GitHub Action fixes it.

<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->
<!-- Closes #XXX -->

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [ ] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [ ] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [ ] I have added tests that prove my fix is effective or that my feature works
