### PR TITLE
Force update to trigger github action

### DIFF
--- a/.github/workflows/publish-mainline.yml
+++ b/.github/workflows/publish-mainline.yml
@@ -34,6 +34,6 @@ jobs:
       - name: Publish
         run: |
           cd packages/flame
-          node ./scripts/check-changed.js && yarn build && npm publish dist --quiet || exit 0
+          yarn release || exit 0
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/publish-mainline.yml
+++ b/.github/workflows/publish-mainline.yml
@@ -34,6 +34,6 @@ jobs:
       - name: Publish
         run: |
           cd packages/flame
-          yarn release || exit 0
+          node ./scripts/check-changed.js && yarn release || exit 0
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -9,7 +9,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ## [Unreleased]
 
-- Force update to trigger new github action workflow
+- Force update to trigger new github action workflow ([#62](https://github.com/lightspeed/flame/pull/62))
 
 ## 1.2.5 - 2019-12-10
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+- Force update to trigger new github action workflow
+
 ## 1.2.5 - 2019-12-10
 
 ### Fixed

--- a/packages/flame/src/Alert/Alert.tsx
+++ b/packages/flame/src/Alert/Alert.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { transparentize } from 'polished';
 import { space, variant, SpaceProps } from 'styled-system';
 import { themeGet } from '@styled-system/theme-get';
+
 import { Flex, Box } from '../Core';
 import { Text } from '../Text';
 


### PR DESCRIPTION
## Description

Github action to publish mainline was not using `yarn release`. Simply leverage it and do a small dummy change