### PR TITLE
Revert @types/react package update, use locked version

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,14 +71,12 @@
     "@types/jest": "^24.0.15",
     "@types/lodash": "^4.14.123",
     "@types/luxon": "^1.15.2",
-    "@types/react": "16.8.23",
+    "@types/react": "^16.8.23",
     "@types/react-click-outside": "^3.0.3",
     "@types/react-modal": "^3.8.1",
     "@types/react-select": "^2.0.15",
     "@types/react-test-renderer": "^16.8.3",
     "@types/storybook-readme": "^5.0.3",
-    "@types/storybook__addon-actions": "^3.4.3",
-    "@types/storybook__react": "^4.0.2",
     "@types/styled-system": "^5.0.0",
     "array-move": "^2.1.0",
     "autoprefixer": "^8.0.0",
@@ -125,6 +123,9 @@
     "webpack": "^4.41.2",
     "webpack-cli": "^2.1.3",
     "yargs": "^11.0.0"
+  },
+  "resolutions": {
+    "@types/react": "16.8.23"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,json,css,scss,md}": [

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/jest": "^24.0.15",
     "@types/lodash": "^4.14.123",
     "@types/luxon": "^1.15.2",
-    "@types/react": "^16.9.16",
+    "@types/react": "16.8.23",
     "@types/react-click-outside": "^3.0.3",
     "@types/react-modal": "^3.8.1",
     "@types/react-select": "^2.0.15",

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Dependencies
+
+- Revert @types/react package update, use locked version ([#64](https://github.com/lightspeed/flame/pull/64))
+
 ## 1.2.6 - 2019-12-10
+
+### Fixed
 
 - Force update to trigger new github action workflow ([#62](https://github.com/lightspeed/flame/pull/62))
 

--- a/packages/flame/package.json
+++ b/packages/flame/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@babel/core": "^7.1.6",
     "@lightspeed/flame-tokens": "^1.0.0",
-    "@types/react": "^16.9.16",
+    "@types/react": "16.8.23",
     "@types/storybook-readme": "^4.0.0",
     "concurrently": "^3.5.1",
     "fs-extra": "7.0.1",

--- a/packages/flame/package.json
+++ b/packages/flame/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@babel/core": "^7.1.6",
     "@lightspeed/flame-tokens": "^1.0.0",
-    "@types/react": "16.8.23",
+    "@types/react": "^16.8.23",
     "@types/storybook-readme": "^4.0.0",
     "concurrently": "^3.5.1",
     "fs-extra": "7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3304,15 +3304,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "16.9.16"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.16.tgz#4f12515707148b1f53a8eaa4341dae5dfefb066d"
-  integrity sha512-dQ3wlehuBbYlfvRXfF5G+5TbZF3xqgkikK7DWAsQXe2KnzV+kjD4W2ea+ThCrKASZn9h98bjjPzoTYzfRqyBkw==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^2.2.0"
-
-"@types/react@16.8.23":
+"@types/react@*", "@types/react@16.8.23", "@types/react@^16.8.23":
   version "16.8.23"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.23.tgz#ec6be3ceed6353a20948169b6cb4c97b65b97ad2"
   integrity sha512-abkEOIeljniUN9qB5onp++g0EY38h7atnDHxwKUFz1r3VH1+yG1OKi2sNPTyObL40goBmfKFpdii2lEzwLX1cA==
@@ -3339,30 +3331,12 @@
   dependencies:
     "@types/react" "*"
 
-"@types/storybook__addon-actions@^3.4.3":
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/@types/storybook__addon-actions/-/storybook__addon-actions-3.4.3.tgz#bb0c3fd066e1f495d3f2b724487e2b99194b3f1a"
-  integrity sha512-RSFFfruUHL7La4CZpuiKZ0mZvr5orjenFA2jc31tfPwvA3fYNH4/9XSfA2MB08IpJbF3aErtYWT5Dtigkxnltg==
-
-"@types/storybook__react@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@types/storybook__react/-/storybook__react-4.0.2.tgz#f36fb399574c662e79c1a0cf6e429b6ff730da40"
-  integrity sha512-U/+J5qccRdKFryvHkk1a0IeZaSIZLCmTwAQhTSDGeC3SPNIYPus+EtunBqP49r870l8czbfxtjeC3IL9P66ngQ==
-  dependencies:
-    "@types/react" "*"
-    "@types/webpack-env" "*"
-
 "@types/styled-system@^5.0.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/styled-system/-/styled-system-5.1.1.tgz#22eff9e4b2f89cd2222c15053f8c11be5ec9c357"
   integrity sha512-RAF9Erif51vbD1ZbIiGN4ZrgxpSr44iMXrPjQK5+tI7PWLDugKepTWj7T/LqG5VfaYYIrEmOCzIpulhv+/D/XQ==
   dependencies:
     csstype "^2.6.4"
-
-"@types/webpack-env@*":
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.14.0.tgz#8edfc5f8e6eae20eeed3ca0d02974ed4ee5e4efc"
-  integrity sha512-Fv+0gYJzE/czLoRKq+gnXWr4yBpPM3tO3C8pDLFwqVKlMICQUq5OsxwwFZYDaVr7+L6mgNDp16iOcJHEz3J5RQ==
 
 "@types/webpack-env@^1.13.7":
   version "1.14.1"
@@ -6800,9 +6774,9 @@ css-loader@^0.28.11:
     source-list-map "^2.0.0"
 
 css-loader@^3.0.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.2.1.tgz#62849b45a414b7bde0bfba17325a026471040eae"
-  integrity sha512-q40kYdcBNzMvkIImCL2O+wk8dh+RGwPPV9Dfz3n7XtOYPXqe2Z6VgtvoxjkLHz02gmhepG9sOAJOUlx+3hHsBg==
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.3.0.tgz#65f889807baec3197313965d6cda9899f936734d"
+  integrity sha512-x9Y1vvHe5RR+4tzwFdWExPueK00uqFTCw7mZy+9aE/X1SKWOArm5luaOrtJ4d05IpOwJ6S86b/tVcIdhw1Bu4A==
   dependencies:
     camelcase "^5.3.1"
     cssesc "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3304,10 +3304,18 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.9.16":
+"@types/react@*":
   version "16.9.16"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.16.tgz#4f12515707148b1f53a8eaa4341dae5dfefb066d"
   integrity sha512-dQ3wlehuBbYlfvRXfF5G+5TbZF3xqgkikK7DWAsQXe2KnzV+kjD4W2ea+ThCrKASZn9h98bjjPzoTYzfRqyBkw==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
+"@types/react@16.8.23":
+  version "16.8.23"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.23.tgz#ec6be3ceed6353a20948169b6cb4c97b65b97ad2"
+  integrity sha512-abkEOIeljniUN9qB5onp++g0EY38h7atnDHxwKUFz1r3VH1+yG1OKi2sNPTyObL40goBmfKFpdii2lEzwLX1cA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"


### PR DESCRIPTION
## Description

Upgrading `@types/react` was not a good idea, it created issues with packages relying on Flame. Reverted back to `16.8.23` and use `resolutions` to force all sub-dependencies to also use this version. This is needed because `@storybook/*` packages have `@types/react@*` as deps.

<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->
<!-- Closes #XXX -->

## How to test?

- CI (type-checking mainly) should still pass ✅ 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [ ] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [ ] I have added tests that prove my fix is effective or that my feature works
