### PR TITLE
Add default offsetOption to usePopper to preserve old behavior

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Fixed
+
+- Set initial offset within the usePopper hook, instead of within the DropdownContainer to preserve old behavior. Offset should be handled via the hook anyways
+
 ## 1.2.7 - 2019-12-10
 
 ### Dependencies

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -11,7 +11,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ### Fixed
 
-- Set initial offset within the usePopper hook, instead of within the DropdownContainer to preserve old behavior. Offset should be handled via the hook anyways
+- Set initial offset within the usePopper hook, instead of within the DropdownContainer to preserve old behavior. Offset should be handled via the hook anyways ([#65](https://github.com/lightspeed/flame/pull/65))
 
 ## 1.2.7 - 2019-12-10
 

--- a/packages/flame/src/Dropdown/Dropdown.tsx
+++ b/packages/flame/src/Dropdown/Dropdown.tsx
@@ -120,12 +120,6 @@ const Dropdown: React.FC<Props> = ({
 
   usePopper(targetRef, popperRef, {
     placement: (placementWhitelist[placement] as any) || placement || 'bottom-start',
-    modifiers: {
-      offset: {
-        enabled: true,
-        offset: '0px, 8px',
-      },
-    },
   });
 
   const { isActive, toggle, setInactive } = useToggle(!!initiallyOpen);

--- a/packages/flame/src/hooks/usePopper.ts
+++ b/packages/flame/src/hooks/usePopper.ts
@@ -1,10 +1,19 @@
 import * as React from 'react';
 import PopperJs, { PopperOptions, Data } from 'popper.js';
 
+const defaultOptions: PopperOptions = {
+  placement: 'bottom',
+  modifiers: {
+    offset: {
+      enabled: true,
+      offset: '0px, 8px',
+    },
+  },
+};
 export function usePopper(
   targetRef: React.RefObject<any>,
   popperRef: React.RefObject<any>,
-  options: PopperOptions = { placement: 'bottom' },
+  options: PopperOptions = {},
 ) {
   const [placement, setPlacement] = React.useState(options.placement);
 
@@ -12,6 +21,7 @@ export function usePopper(
     let popperInstance: PopperJs | null = null;
     if (targetRef.current && popperRef.current && !popperInstance) {
       popperInstance = new PopperJs(targetRef.current, popperRef.current, {
+        ...defaultOptions,
         ...options,
         onCreate: (data: Data) => {
           if (placement !== data.placement) {


### PR DESCRIPTION
## Description

If using the usePopper option in conjunction with the DropdownContainer, you may have noticed that the positioning is off. This is because we are now leveraging popper's offset options instead of relying purely on CSS positioning, as that can be inaccurate for positioning.

This PR will bake in the default dropdown offset (our recommended offset value anyways) to the usePopper hook. This value can of course, be overwritten.