### PR TITLE
Adjust docgen script, fix documentations for components

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Fixed
+
+- Merge more styled system props via the docgen script ([#67](https://github.com/lightspeed/flame/pull/67))
+- Leverage inlined named exports instead of an named export object to help the ts doc parser ([#67](https://github.com/lightspeed/flame/pull/67))
+
 ## 1.2.8 - 2019-12-11
 
 ### Fixed

--- a/packages/flame/scripts/docgen.js
+++ b/packages/flame/scripts/docgen.js
@@ -20,6 +20,8 @@ const getStyledSystemDocsUrl = parentPropName => {
   switch (parentPropName) {
     case 'PositionProps':
       return 'https://styled-system.com/api#position';
+    case 'ColorProps':
+      return 'https://styled-system.com/api#color';
     case 'BorderProps':
       return 'https://styled-system.com/api#border';
     case 'BackgroundProps':
@@ -34,6 +36,70 @@ const getStyledSystemDocsUrl = parentPropName => {
       return 'https://styled-system.com/api#space';
     default:
       return 'https://styled-system.com/api';
+  }
+};
+
+const namespaceType = parentName => {
+  switch (parentName) {
+    case 'WidthProps':
+    case 'HeightProps':
+    case 'MinWidthProps':
+    case 'MinHeightProps':
+    case 'MaxWidthProps':
+    case 'MaxHeightProps':
+    case 'DisplayProps':
+    case 'VerticalAlignProps':
+    case 'SizeProps':
+      return 'LayoutProps';
+    case 'FontFamilyProps':
+    case 'FontSizeProps':
+    case 'FontWeightProps':
+    case 'LineHeightProps':
+    case 'LetterSpacingProps':
+    case 'FontStyleProps':
+    case 'TextAlignProps':
+      return 'TypographyProps';
+    case 'AlignItemsProps':
+    case 'AlignContentProps':
+    case 'JustifyItemsProps':
+    case 'JustifyContentProps':
+    case 'FlexWrapProps':
+    case 'FlexDirectionProps':
+    case 'FlexProps':
+    case 'FlexGrowProps':
+    case 'FlexShrinkProps':
+    case 'FlexBasisProps':
+    case 'JustifySelfProps':
+    case 'AlignSelfProps':
+    case 'OrderProps':
+      return 'FlexboxProps';
+    case 'ZIndexProp':
+    case 'TopProps':
+    case 'RightProps':
+    case 'BottomProps':
+    case 'LeftProps':
+      return 'PositionProps';
+    case 'BorderWidthProps':
+    case 'BorderStyleProps':
+    case 'BorderColorProps':
+    case 'BorderRadiusProps':
+    case 'BorderTopProps':
+    case 'BorderRightProps':
+    case 'BorderBottomProps':
+    case 'BorderLeftProps':
+      return 'BorderProps';
+    case 'borderRadius':
+    case 'borderTopLeftRadius':
+    case 'borderTopRightRadius':
+    case 'borderBottomLeftRadius':
+    case 'borderBottomRightRadius':
+      return 'BorderRadiusProps';
+    case 'TextColorProps':
+    case 'BackgroundColorProps':
+    case 'OpacityProps':
+      return 'ColorProps';
+    default:
+      return parentName;
   }
 };
 
@@ -54,15 +120,17 @@ const componentjsonStructure = filePaths.reduce((acc, file) => {
       if (
         value.parent &&
         value.parent.fileName &&
-        value.parent.fileName.includes(styledSystemFileName)
+        (value.parent.fileName.includes(styledSystemFileName) ||
+          value.parent.fileName.includes('Core/index'))
       ) {
         return {
           ...acc2,
-          [value.parent.name]: {
+          [namespaceType(value.parent.name)]: {
             description: `Styled System Properties. Please consult the appropriate documentation on ${getStyledSystemDocsUrl(
-              value.parent.name,
+              namespaceType(value.parent.name),
             )}`,
-            name: value.parent.name,
+            documentationUrl: getStyledSystemDocsUrl(namespaceType(value.parent.name)),
+            name: namespaceType(value.parent.name),
           },
         };
       }

--- a/packages/flame/src/Alert/Alert.tsx
+++ b/packages/flame/src/Alert/Alert.tsx
@@ -65,7 +65,7 @@ export interface AlertProps {
 /**
  * An alert can be a warning following an action, a helpful tip or an important update about a system issue. There are four types of alert and each has a different function.
  */
-const Alert: React.FC<AlertProps & SpaceProps> = ({
+export const Alert: React.FC<AlertProps & SpaceProps> = ({
   children,
   type = 'info',
   title,
@@ -128,5 +128,3 @@ const Alert: React.FC<AlertProps & SpaceProps> = ({
     </AlertWrapper>
   );
 };
-
-export { Alert };

--- a/packages/flame/src/Button/Button.tsx
+++ b/packages/flame/src/Button/Button.tsx
@@ -177,7 +177,7 @@ export type ButtonProps = Merge<
 /**
  * Buttons are used to take action or confirm a decision. They help merchants get things done.
  */
-const Button: React.FunctionComponent<ButtonProps> = ({
+export const Button: React.FunctionComponent<ButtonProps> = ({
   loading,
   children,
   size,
@@ -230,5 +230,3 @@ Button.defaultProps = {
   variant: 'neutral',
   block: false,
 };
-
-export { Button };

--- a/packages/flame/src/Checkbox/Checkbox.tsx
+++ b/packages/flame/src/Checkbox/Checkbox.tsx
@@ -7,7 +7,7 @@ import { IconCheckmark } from '../Icon/Checkmark';
 import { TextProps } from '../Text';
 import { RadioLabel } from '../Radio';
 
-const CheckboxLabel = RadioLabel;
+export const CheckboxLabel = RadioLabel;
 
 const Wrapper = styled('div')`
   position: relative;
@@ -93,11 +93,13 @@ const CheckboxInput = styled('input')<{ indeterminate: boolean }>`
 
 export type CheckboxDescriptionProps = Merge<React.HTMLProps<HTMLDivElement>, TextProps>;
 export interface BaseCheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  /** Set the checkbox to an indeterminate state */
   indeterminate?: boolean;
+  /** Set the checkbox to a checked state */
   checked?: boolean;
   css?: any;
 }
-const BaseCheckbox = React.forwardRef<HTMLInputElement, BaseCheckboxProps>(
+export const BaseCheckbox = React.forwardRef<HTMLInputElement, BaseCheckboxProps>(
   ({ indeterminate, checked, ...restProps }, ref) => (
     <Wrapper>
       <CheckboxInput
@@ -116,14 +118,15 @@ const BaseCheckbox = React.forwardRef<HTMLInputElement, BaseCheckboxProps>(
 );
 
 export interface CheckboxProps extends BaseCheckboxProps {
+  /** The label text that appears right besides the checkbox */
   label?: React.ReactNode;
+  /** Helper text that will be inserted below the checkbox */
   description?: React.ReactNode;
-  css?: any;
 }
 /**
  * Used to specify choices among large groups of options.
  */
-const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
+export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
   ({ label, id, description, disabled, ...restProps }, ref) => {
     return (
       <React.Fragment>
@@ -135,5 +138,3 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
     );
   },
 );
-
-export { Checkbox, CheckboxLabel, BaseCheckbox };

--- a/packages/flame/src/Dialog/Dialog.tsx
+++ b/packages/flame/src/Dialog/Dialog.tsx
@@ -42,7 +42,7 @@ export type DialogProps = Partial<OptionalProps> & {
 /**
  * A simpler Modal, Dialogs present users with a simple question and require a simple answer.
  */
-const Dialog: React.FC<DialogProps> = props => {
+export const Dialog: React.FC<DialogProps> = props => {
   const {
     type,
     title,
@@ -95,5 +95,3 @@ Dialog.defaultProps = {
   isLoading: false,
   scroll: false,
 };
-
-export { Dialog };

--- a/packages/flame/src/Dropdown/Dropdown.tsx
+++ b/packages/flame/src/Dropdown/Dropdown.tsx
@@ -57,7 +57,7 @@ const containerIsActive = (props: { isActive: boolean; placement?: Placement }) 
 
 const animSpeed = 'transition.transition-duration-fast';
 
-const DropdownContainer = styled(BasePopoverContainer)<{
+export const DropdownContainer = styled(BasePopoverContainer)<{
   isActive: boolean;
   placement?: Placement;
 }>`
@@ -86,7 +86,7 @@ const DropdownContainer = styled(BasePopoverContainer)<{
 )} ease-in-out, top ${themeGet(animSpeed, '100ms')} ease-in-out;
 `;
 
-const DropdownContent: React.FC<FlameBoxProps> = ({ children, ...restProps }) => (
+export const DropdownContent: React.FC<FlameBoxProps> = ({ children, ...restProps }) => (
   <Box my={2} mx={2} {...restProps}>
     {children}
   </Box>
@@ -98,7 +98,7 @@ const placementWhitelist: { [key: string]: string } = {
   end: 'bottom-end',
 };
 
-const useDropdown = () => {
+export const useDropdown = () => {
   const { closeDropdown } = React.useContext(Context);
   return { closeDropdown };
 };
@@ -106,7 +106,7 @@ const useDropdown = () => {
 /**
  * When there is too much to show, place your precious UI in here.
  */
-const Dropdown: React.FC<Props> = ({
+export const Dropdown: React.FC<Props> = ({
   buttonContent,
   placement = 'start',
   initiallyOpen = false,
@@ -176,5 +176,3 @@ const Dropdown: React.FC<Props> = ({
     </Context.Provider>
   );
 };
-
-export { Dropdown, DropdownContent, DropdownContainer, useDropdown };

--- a/packages/flame/src/Input/Input.tsx
+++ b/packages/flame/src/Input/Input.tsx
@@ -14,12 +14,13 @@ import { IconWarning } from '../Icon/Warning';
 import { IconDanger } from '../Icon/Danger';
 
 type StatusType = 'valid' | 'error' | 'warning';
-type InputSizes = 'small' | 'regular' | 'large';
 
 type StyledInputProps = {
-  inputSize?: InputSizes;
+  /** Set the size of the input */
+  inputSize?: 'small' | 'regular' | 'large';
   hasSuffix?: boolean;
   hasPrefix?: boolean;
+  /** Sets the element to read-only. The content will be selectable, but not editable */
   readOnly?: boolean;
 };
 const StyledInput = styled('input')<StyledInputProps>`
@@ -102,7 +103,7 @@ const StyledInput = styled('input')<StyledInputProps>`
 interface InputBackdropProps extends BorderProps {
   status?: StatusType;
 }
-const InputBackdrop = styled('div')<InputBackdropProps>`
+export const InputBackdrop = styled('div')<InputBackdropProps>`
   position: absolute;
   top: 0;
   bottom: 0;
@@ -213,15 +214,18 @@ export type BaseInputProps = Merge<
   Omit<StyledInputProps, 'inputSize'>
 > &
   InputBackdropProps & {
-    size?: InputSizes;
+    size?: 'small' | 'regular' | 'large';
     status?: StatusType;
     disabled?: boolean;
+    /** (Legacy) Was this element automatically filled by the browser? */
     isAutofilled?: boolean;
+    /** Element to show inside the input on the left hand side. Usually reserved for Icons */
     prefix?: React.ReactNode;
+    /** Element to show inside the input on the right hand side. Usually reserved for Icons */
     suffix?: React.ReactNode;
     css?: any;
   };
-const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
+export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
   (
     {
       size,
@@ -297,12 +301,18 @@ const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
   },
 );
 
-export interface InputProps extends Omit<BaseInputProps, 'status'> {
+export interface InputProps extends Omit<BaseInputProps, 'status' | 'hasPrefix' | 'hasSuffix'> {
+  /** The text label that will appear above the Input */
   label?: React.ReactNode;
+  /** Helper element that will be positioned to the top right of the Input */
   labelHelper?: React.ReactNode;
+  /** Paragraph that will appear beneath the label */
   description?: React.ReactNode;
+  /** If a status is present, this content will appear on the bottom of the Input */
   statusMessage?: React.ReactNode;
+  /** Paragraph that will appear on the bottom of the Input */
   textHelper?: React.ReactNode;
+  /** Set the status of the Input */
   status?:
     | StatusType
     | {
@@ -315,7 +325,7 @@ export interface InputProps extends Omit<BaseInputProps, 'status'> {
 /**
  * The Acceptor of User Information, Messenger of the Internet Gods.
  */
-const Input = React.forwardRef<HTMLInputElement, InputProps>(
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
   (
     { label, id, status, description, statusMessage, textHelper, labelHelper, ...restProps },
     ref,
@@ -371,5 +381,3 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 // Keeping flameName for compat with Group & inputBlock prop. Will be deprecated.
 // @ts-ignore
 Input.flameName = 'Input';
-
-export { Input, InputBackdrop, BaseInput };

--- a/packages/flame/src/InputGroup/InputGroup.tsx
+++ b/packages/flame/src/InputGroup/InputGroup.tsx
@@ -10,7 +10,7 @@ export interface InputGroupAddonProps
     BorderProps,
     Partial<Omit<ColorProps, 'color'>>,
     ZIndexProps {}
-const InputGroupAddon = styled(Flex)<InputGroupAddonProps>`
+export const InputGroupAddon = styled(Flex)<InputGroupAddonProps>`
   padding-left: ${themeGet('space.2')};
   padding-right: ${themeGet('space.2')};
   text-align: center;
@@ -29,7 +29,7 @@ const InputGroupAddon = styled(Flex)<InputGroupAddonProps>`
 /**
  * A wrapper component used to combine other components into a single cohesive whole.
  */
-const InputGroup: React.FC<FlameFlexProps> = ({ children, ...restProps }) => {
+export const InputGroup: React.FC<FlameFlexProps> = ({ children, ...restProps }) => {
   const nextChildren = React.Children.map(children, (child: any, index) => {
     if (!child) {
       return null;
@@ -67,6 +67,4 @@ const InputGroup: React.FC<FlameFlexProps> = ({ children, ...restProps }) => {
   return <Flex {...restProps}>{nextChildren}</Flex>;
 };
 
-const BeThereOrBeSquare = InputGroup;
-
-export { InputGroup, InputGroupAddon, BeThereOrBeSquare };
+export const BeThereOrBeSquare = InputGroup;

--- a/packages/flame/src/Popover/Popover.tsx
+++ b/packages/flame/src/Popover/Popover.tsx
@@ -88,7 +88,7 @@ const PopperWrapper: React.FC<PopperWrapper> = ({
 /**
  * A small extension of an action taken, containing information, or more actions still.
  */
-const Popover: React.FC<PopoverProps> = ({
+export const Popover: React.FC<PopoverProps> = ({
   className,
   isOpen = false,
   target,
@@ -165,4 +165,5 @@ const Popover: React.FC<PopoverProps> = ({
   );
 };
 
-export { Popover, PopoverPlacement };
+// TODO: This needs to be removed since it potentially breaks
+export { PopoverPlacement };

--- a/packages/flame/src/Progress/Progress.tsx
+++ b/packages/flame/src/Progress/Progress.tsx
@@ -62,7 +62,7 @@ export type ProgressProps = Merge<
 /**
  * A linear indicator showing the progression of longstanding tasks.
  */
-const Progress: React.FunctionComponent<ProgressProps> = ({
+export const Progress: React.FunctionComponent<ProgressProps> = ({
   type,
   current,
   total,
@@ -77,5 +77,3 @@ const Progress: React.FunctionComponent<ProgressProps> = ({
     </ProgressBarWrapper>
   );
 };
-
-export { Progress };

--- a/packages/flame/src/Radio/Radio.tsx
+++ b/packages/flame/src/Radio/Radio.tsx
@@ -6,7 +6,7 @@ import { Box } from '../Core';
 import { BaseLabel, LabelProps, FormHelper } from '../FormField/FormField';
 
 export interface RadioLabelProps extends LabelProps {}
-const RadioLabel: React.FC<RadioLabelProps> = ({
+export const RadioLabel: React.FC<RadioLabelProps> = ({
   description,
   disabled,
   children,
@@ -80,10 +80,8 @@ const RadioInput = styled('input')`
   }
 `;
 
-export interface RadioProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  css?: any;
-}
-const BaseRadio = React.forwardRef<HTMLInputElement, RadioProps>(({ ...restProps }, ref) => (
+export interface RadioProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+export const BaseRadio = React.forwardRef<HTMLInputElement, RadioProps>(({ ...restProps }, ref) => (
   <WrapperRadio>
     <RadioInput ref={ref} type="radio" {...restProps} />
     <Checkmark>
@@ -93,14 +91,15 @@ const BaseRadio = React.forwardRef<HTMLInputElement, RadioProps>(({ ...restProps
 ));
 
 interface FormRadioProps extends RadioProps {
+  /** The label text that appears right besides the checkbox */
   label?: React.ReactNode;
+  /** Helper text that will be inserted below the checkbox */
   description?: React.ReactNode;
-  css?: any;
 }
 /**
  * Offers users a single choice, among a small set.
  */
-const Radio = React.forwardRef<HTMLInputElement, FormRadioProps>(
+export const Radio = React.forwardRef<HTMLInputElement, FormRadioProps>(
   ({ label, id, description, disabled, ...restProps }, ref) => {
     return (
       <React.Fragment>
@@ -112,5 +111,3 @@ const Radio = React.forwardRef<HTMLInputElement, FormRadioProps>(
     );
   },
 );
-
-export { BaseRadio, RadioLabel, Radio };

--- a/packages/flame/src/Switch/Switch.tsx
+++ b/packages/flame/src/Switch/Switch.tsx
@@ -113,7 +113,7 @@ export type SwitchProps = Merge<
   React.HTMLProps<HTMLInputElement>,
   {
     css?: any;
-    /** CSS class name */
+    /** CSS class name to apply to the wrapper component */
     className?: string;
     /** Sets the checked state of Switch */
     checked?: boolean;
@@ -122,7 +122,7 @@ export type SwitchProps = Merge<
 /**
  * A toggleable control which stays on (or off) until manually triggered once more.
  */
-const Switch: React.FC<SwitchProps> = ({ className, checked, ...restProps }) => (
+export const Switch: React.FC<SwitchProps> = ({ className, checked, ...restProps }) => (
   <WrapperLabel role="presentation" className={className}>
     <SwitchInput type="checkbox" checked={checked} value={checked ? 1 : 0} {...restProps} />
     <SwitchWrapper>
@@ -136,5 +136,3 @@ const Switch: React.FC<SwitchProps> = ({ className, checked, ...restProps }) => 
     </SwitchWrapper>
   </WrapperLabel>
 );
-
-export { Switch };

--- a/packages/flame/src/Tab/Tab.tsx
+++ b/packages/flame/src/Tab/Tab.tsx
@@ -6,12 +6,13 @@ import { Box, Flex, FlameBoxProps } from '../Core';
 import { Divider } from '../Divider';
 
 interface TabsProps {
+  /** Highlight the nav to show that it's currently selected */
   active?: boolean;
 }
 /**
  * Top-level separation of related, but different sections.
  */
-const Tab = styled(Flex)<TabsProps>`
+export const Tab = styled(Flex)<TabsProps>`
   border-bottom: 3px solid transparent;
   cursor: pointer;
   justify-content: center;
@@ -42,7 +43,7 @@ Wrapper.defaultProps = {
   mx: 2,
 };
 
-const TabContainer: React.FC<FlameBoxProps> = ({ children, ...restProps }) => {
+export const TabContainer: React.FC<FlameBoxProps> = ({ children, ...restProps }) => {
   return (
     <Box {...restProps}>
       <Wrapper>{children}</Wrapper>
@@ -50,5 +51,3 @@ const TabContainer: React.FC<FlameBoxProps> = ({ children, ...restProps }) => {
     </Box>
   );
 };
-
-export { TabContainer, Tab };

--- a/packages/flame/src/Tag/Tag.tsx
+++ b/packages/flame/src/Tag/Tag.tsx
@@ -15,8 +15,8 @@ const StyledTag = styled('div')`
 `;
 
 type SetTagLabelSizeProps = {
-  /** One of "normal", "small" */
-  size?: string | 'normal' | 'small';
+  /** Set the overall size of then component. By default, it is set to small. */
+  size?: 'normal' | 'small';
 };
 
 const setTagLabelSize = (props: SetTagLabelSizeProps): SerializedStyles => {
@@ -170,7 +170,13 @@ export type TagProps = Merge<
 /**
  * An organisational indicator specifying of a data point which part of a whole it belongs to.
  */
-const Tag = ({ children, size, onClick, onRemove, ...rest }: TagProps) => (
+export const Tag = ({
+  children,
+  size = 'normal',
+  onClick,
+  onRemove,
+  ...rest
+}: Omit<TagProps, 'hasSuffix'>) => (
   <StyledTag {...rest}>
     <StyledTagLabel type="button" onClick={onClick} hasSuffix={!!onRemove} size={size}>
       {children}
@@ -184,8 +190,5 @@ const Tag = ({ children, size, onClick, onRemove, ...rest }: TagProps) => (
 );
 
 Tag.defaultProps = {
-  size: 'normal',
   onClick: () => {},
 };
-
-export { Tag };

--- a/packages/flame/src/Tag/examples/TagList.tsx
+++ b/packages/flame/src/Tag/examples/TagList.tsx
@@ -3,7 +3,7 @@ import React, { Component, Fragment } from 'react';
 import { Tag } from '../Tag';
 
 type Tags = {
-  size: string;
+  size: 'normal' | 'small';
   label: string;
 };
 

--- a/packages/flame/src/Text/Text.tsx
+++ b/packages/flame/src/Text/Text.tsx
@@ -174,6 +174,7 @@ Heading3.defaultProps = {
 export const Heading4 = styled(BaseText)<TextProps>`
   font-size: ${themeGet('fontSizes.xsmall')};
   line-height: ${themeGet('lineHeights.3')};
+  text-transform: uppercase;
 `.withComponent('h4');
 
 Heading4.defaultProps = {
@@ -181,7 +182,6 @@ Heading4.defaultProps = {
   fontWeight: 'bold',
   color: 'textHeading',
   letterSpacing: 3,
-  textTransform: 'uppercase',
 };
 
 const textlinkColor = (props: any) =>

--- a/packages/flame/src/Text/__snapshots__/Text.test.tsx.snap
+++ b/packages/flame/src/Text/__snapshots__/Text.test.tsx.snap
@@ -67,9 +67,9 @@ exports[`Text Snapshots should render Heading4 with appropriate styles 1`] = `
   -ms-letter-spacing: 0.09375rem;
   letter-spacing: 0.09375rem;
   font-weight: 700;
-  text-transform: uppercase;
   font-size: 0.75rem;
   line-height: 1.125rem;
+  text-transform: uppercase;
 }
 
 <h4

--- a/packages/flame/src/Text/story.tsx
+++ b/packages/flame/src/Text/story.tsx
@@ -83,7 +83,7 @@ stories.add('Body', () => (
         <Text>
           <BodyContent />
         </Text>
-        <Heading4>Heading 4</Heading4>
+        <Heading4 textTransform="lowercase">Heading 4</Heading4>
         <Text size="small">
           <BodyContent />
         </Text>

--- a/packages/flame/src/Text/story.tsx
+++ b/packages/flame/src/Text/story.tsx
@@ -83,7 +83,7 @@ stories.add('Body', () => (
         <Text>
           <BodyContent />
         </Text>
-        <Heading4 textTransform="lowercase">Heading 4</Heading4>
+        <Heading4>Heading 4</Heading4>
         <Text size="small">
           <BodyContent />
         </Text>

--- a/packages/flame/src/Tooltip/Tooltip.tsx
+++ b/packages/flame/src/Tooltip/Tooltip.tsx
@@ -194,8 +194,9 @@ const TooltipContainer = styled('div')<TooltipContainerProps>`
 `;
 
 interface TooltipWrapper extends TooltipContainerProps {
+  /** Element that will have the tooltip hover event bound to */
   targetRef?: React.RefObject<HTMLSpanElement>;
-  /** CSS class name */
+  /** CSS class name to be applied to the wrapper of the tooltip */
   className?: string;
   /** Sets the wrapper tag for Tooltip */
   tag?: string;
@@ -237,7 +238,7 @@ export interface TooltipProps extends TooltipWrapper {
   children: React.ReactNode;
   /** Text content of Tooltip */
   content: string;
-  /** Sets Tooltip visibility */
+  /** Sets whether or not to display the tooltip */
   active?: boolean;
 }
 
@@ -250,7 +251,7 @@ export interface TooltipProps extends TooltipWrapper {
 /**
  * An extra bit of information, contextualized to a portion of a UI.
  */
-const Tooltip: React.FC<TooltipProps> = ({
+export const Tooltip: React.FC<TooltipProps> = ({
   active,
   light,
   className,
@@ -305,4 +306,4 @@ const Tooltip: React.FC<TooltipProps> = ({
   );
 };
 
-export { Tooltip, TooltipPlacement };
+export { TooltipPlacement };


### PR DESCRIPTION
## Description

Docgen script needed to be adjusted to properly concatenate the types together.

I've also taken the time to re-document certain things, as we were missing tsdocs for some components.

Additionally, I needed to do some adjustments to the exports of some components. Nothing major, they still are all named exports, however we cannot leverage the `export {}` notation, as that throws the parser into a fit. This is especially problematic with components that have multiple sub-components. Luckily, no breaking changes and it was quite simply to add in.

I've also previewed the changes directly in gatsby to ensure that the outputs are ok. We should be gucci now.

<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->
<!-- Closes #XXX -->
