### PR TITLE
Handle checkbox indeterminate state at the DOM level

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -11,7 +11,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ### Fixed
 
-- Add in indeterminate state at the DOM level for Checkbox component
+- Add in indeterminate state at the DOM level for Checkbox component ([#73](https://github.com/lightspeed/flame/pull/73))
 
 ## 1.2.10 - 2019-12-17
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Fixed
+
+- Add in indeterminate state at the DOM level for Checkbox component
+
 ## 1.2.10 - 2019-12-17
 
 ### Fixed

--- a/packages/flame/src/Checkbox/Checkbox.test.tsx
+++ b/packages/flame/src/Checkbox/Checkbox.test.tsx
@@ -89,4 +89,13 @@ describe('<Checkbox />', () => {
       getByText('my description');
     });
   });
+
+  describe('Behaviours', () => {
+    it('handles indeterminate state at the DOM level', () => {
+      const ref = React.createRef<HTMLInputElement>();
+      customRender(<Checkbox indeterminate ref={ref} />);
+
+      expect(ref.current.indeterminate).toBeTruthy();
+    });
+  });
 });

--- a/packages/flame/src/Checkbox/Checkbox.tsx
+++ b/packages/flame/src/Checkbox/Checkbox.tsx
@@ -100,21 +100,33 @@ export interface BaseCheckboxProps extends React.InputHTMLAttributes<HTMLInputEl
   checked?: boolean;
 }
 export const BaseCheckbox = React.forwardRef<HTMLInputElement, BaseCheckboxProps>(
-  ({ indeterminate, checked, css, className, ...restProps }, ref) => (
-    <Wrapper css={css} className={className}>
-      <CheckboxInput
-        ref={ref}
-        type="checkbox"
-        indeterminate={indeterminate}
-        checked={checked}
-        {...restProps}
-      />
-      <CheckboxCheckmarkWrapper indeterminate={indeterminate}>
-        <StyledIcon size="0.65rem" />
-        {indeterminate && !checked && <CheckboxIndeterminate />}
-      </CheckboxCheckmarkWrapper>
-    </Wrapper>
-  ),
+  ({ indeterminate, checked, css, className, ...restProps }, ref) => {
+    return (
+      <Wrapper css={css} className={className}>
+        <CheckboxInput
+          ref={innerRef => {
+            if (innerRef) {
+              // eslint-disable-next-line no-param-reassign
+              innerRef.indeterminate = !checked && indeterminate;
+            }
+
+            if (ref) {
+              // @ts-ignore
+              typeof ref === 'function' ? ref(innerRef) : (ref.current = innerRef); // eslint-disable-line no-param-reassign
+            }
+          }}
+          type="checkbox"
+          indeterminate={indeterminate}
+          checked={checked}
+          {...restProps}
+        />
+        <CheckboxCheckmarkWrapper indeterminate={indeterminate}>
+          <StyledIcon size="0.65rem" />
+          {indeterminate && !checked && <CheckboxIndeterminate />}
+        </CheckboxCheckmarkWrapper>
+      </Wrapper>
+    );
+  },
 );
 
 export interface CheckboxProps extends BaseCheckboxProps {


### PR DESCRIPTION
## Description

Need to forward the indeterminate state to the component. ez-pz

closes #72 

## How to test?

- Checkout branch, run `yarn test`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [x] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [x] I have added tests that prove my fix is effective or that my feature works
