### PR TITLE
Update textDimmed color alias + apply to AnnotatedLayout description

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -12,6 +12,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 ### Fixed
 
 - Update `textDimmed` color alias to `gray-600` for flame theme ([#78](https://github.com/lightspeed/flame/pull/78))
+- Use `textDimmed` alias for AnnotatedLayout description ([#78](https://github.com/lightspeed/flame/pull/78))
 
 ## 1.6.0 - 2020-05-25
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Fixed
+
+- Update `textDimmed` color alias to `gray-600` for flame theme ([#78](https://github.com/lightspeed/flame/pull/78))
+
 ## 1.6.0 - 2020-05-25
 
 ### Added

--- a/packages/flame/src/Layout/examples/story.tsx
+++ b/packages/flame/src/Layout/examples/story.tsx
@@ -60,38 +60,30 @@ const FakeContent = () => (
   </React.Fragment>
 );
 
-stories.add(
-  'Annotated Layout',
-  () => (
-    <div style={{ maxWidth: '66rem' }}>
-      <AnnotatedLayout
-        title="Settlement Summary"
-        description="Main information of the money you collected through card payments."
-      >
-        <FakeContent />
-      </AnnotatedLayout>
-    </div>
-  ),
-  { percy: { skip: true } },
-);
+stories.add('Annotated Layout', () => (
+  <div style={{ maxWidth: '66rem' }}>
+    <AnnotatedLayout
+      title="Settlement Summary"
+      description="Main information of the money you collected through card payments."
+    >
+      <FakeContent />
+    </AnnotatedLayout>
+  </div>
+));
 
-stories.add(
-  'Annotated Layout - with actions',
-  () => (
-    <div style={{ maxWidth: '66rem' }}>
-      <AnnotatedLayout
-        title="Settlement Summary"
-        description="Main information of the money you collected through card payments."
-        renderExtras={
-          <Box>
-            <Button>Export</Button>
-          </Box>
-        }
-        mb={5}
-      >
-        <FakeContent />
-      </AnnotatedLayout>
-    </div>
-  ),
-  { percy: { skip: true } },
-);
+stories.add('Annotated Layout - with actions', () => (
+  <div style={{ maxWidth: '66rem' }}>
+    <AnnotatedLayout
+      title="Settlement Summary"
+      description="Main information of the money you collected through card payments."
+      renderExtras={
+        <Box>
+          <Button>Export</Button>
+        </Box>
+      }
+      mb={5}
+    >
+      <FakeContent />
+    </AnnotatedLayout>
+  </div>
+));

--- a/packages/flame/src/Layout/index.tsx
+++ b/packages/flame/src/Layout/index.tsx
@@ -23,11 +23,11 @@ export const AnnotatedLayout: React.FunctionComponent<AnnotatedLayoutProps> = ({
 }) => (
   <Flex flexWrap="wrap" {...(restProps as any)}>
     <Box width={[1, 1 / 3, 1 / 4]} pr={[0, 2]}>
-      <Heading4 mb="1">{title}</Heading4>
-      <Text size="small" color="gray-300" mb={3}>
+      <Heading4 mb={1}>{title}</Heading4>
+      <Text size="small" color="textDimmed" pb={3}>
         {description}
       </Text>
-      {renderExtras && <Box mb={3}>{renderExtras}</Box>}
+      {renderExtras && <Box pb={3}>{renderExtras}</Box>}
     </Box>
     <Box width={[1, 2 / 3, 3 / 4]}>{children}</Box>
   </Flex>

--- a/packages/flame/src/Layout/index.tsx
+++ b/packages/flame/src/Layout/index.tsx
@@ -24,10 +24,10 @@ export const AnnotatedLayout: React.FunctionComponent<AnnotatedLayoutProps> = ({
   <Flex flexWrap="wrap" {...(restProps as any)}>
     <Box width={[1, 1 / 3, 1 / 4]} pr={[0, 2]}>
       <Heading4 mb={1}>{title}</Heading4>
-      <Text size="small" color="textDimmed" pb={3}>
+      <Text size="small" color="textDimmed" mb={3}>
         {description}
       </Text>
-      {renderExtras && <Box pb={3}>{renderExtras}</Box>}
+      {renderExtras && <Box mb={3}>{renderExtras}</Box>}
     </Box>
     <Box width={[1, 2 / 3, 3 / 4]}>{children}</Box>
   </Flex>

--- a/packages/flame/themes/flame/colors.ts
+++ b/packages/flame/themes/flame/colors.ts
@@ -10,7 +10,7 @@ const aliases: ColorAliases = {
   white: themeColors.white,
   textBody: themeColors['gray-700'],
   textHeading: themeColors['gray-1000'],
-  textDimmed: themeColors['gray-500'],
+  textDimmed: themeColors['gray-600'],
   dimmed: themeColors['gray-50'],
   disabled: themeColors['gray-100'],
   bodyBg: themeColors['gray-50'],


### PR DESCRIPTION
## Description

Opening in favor of #78. Also updating AnnotatedLayout description text color to use `textDimmed` instead of the hard-coded `gray-300` value.

<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [x] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [x] I have added tests that prove my fix is effective or that my feature works
