### PR TITLE
Enable publish workflow on next branch

### DIFF
--- a/.github/workflows/publish-lerna.yml
+++ b/.github/workflows/publish-lerna.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+      - next
 name: Publish lerna
 jobs:
   publish:

--- a/.github/workflows/publish-mainline.yml
+++ b/.github/workflows/publish-mainline.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+      - next
 name: Publish mainline
 jobs:
   publish:


### PR DESCRIPTION
## Description

So that we can do `rc` releases from `next`.

<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->
<!-- Closes #XXX -->

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [ ] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [ ] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [ ] I have added tests that prove my fix is effective or that my feature works
