### PR TITLE
Adjust line-height in Alert to be normal.

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -32,6 +32,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 - Icons in Alert will now automatically assign the right color that matches the type of Alert ([#82](https://github.com/lightspeed/flame/pull/82))
 - Icons in Alert will now be properly centered ([#82](https://github.com/lightspeed/flame/pull/82))
 - Tweak css selectors for TextContent to adapt to how emotion handles specificities ([#92](https://github.com/lightspeed/flame/pull/92))
+- Normalize line-height for Alert and AlertInCard ([#101](https://github.com/lightspeed/flame/pull/101))
 
 ## 1.6.1 - 2020-06-05
 

--- a/packages/flame/src/Alert/Alert.tsx
+++ b/packages/flame/src/Alert/Alert.tsx
@@ -65,6 +65,7 @@ export const Alert: React.FC<AlertProps & SpaceProps> = ({
         borderRadius: 'radius-2',
         px: 3,
         py: 2,
+        lineHeight: 'normal',
         variant: `alertVariants.${type}`,
       })}
       {...restProps}
@@ -79,9 +80,7 @@ export const Alert: React.FC<AlertProps & SpaceProps> = ({
               {title}
             </Text>
           )}
-          <Text fontSize={['text', 'text-s']} lineHeight={[3, 2]}>
-            {children}
-          </Text>
+          <Text fontSize={['text', 'text-s']}>{children}</Text>
         </Box>
       </Flex>
       {!noCloseBtn && <CloseButton onClick={handleClose} />}

--- a/packages/flame/src/Alert/AlertInCard.tsx
+++ b/packages/flame/src/Alert/AlertInCard.tsx
@@ -36,13 +36,14 @@ const AlertInCard: React.FC<Props> = ({
         borderRadius: 'radius-2',
         border: '1px solid',
         variant: `alertInCardVariants.${type}`,
+        lineHeight: 'normal',
       })}
       {...restProps}
     >
       <Flex className="fl-alert__icon" flex={0} mt="-1px">
         <AlertIcons type={type} />
       </Flex>
-      <Text css={css({ flex: '1' })} fontSize={['text', 'text-s']} lineHeight={[3, 2]} pl={2}>
+      <Text css={css({ flex: '1' })} fontSize={['text', 'text-s']} px={2}>
         {children}
       </Text>
       {!noCloseBtn && (


### PR DESCRIPTION
## Description

Line height was borking up in DSD.

Force set it to normalize to preserve proper styling.

<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->
<!-- Closes #XXX -->

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [x] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [x] I have added tests that prove my fix is effective or that my feature works
