### PR TITLE
Force Update active poppers. Fix clickOutside handler

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -11,8 +11,8 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ### Fixed
 
-- Leverage `update` hook to re-compute popper positioning in components that have popper still visible.
-- In `useOnClickOutside`, use a ref for handler callback to avoid destroying the event listener too early.
+- Leverage `update` hook to re-compute popper positioning in components that have popper still visible. ([#105](https://github.com/lightspeed/flame/pull/105)
+- In `useOnClickOutside`, use a ref for handler callback to avoid destroying the event listener too early. ([#105](https://github.com/lightspeed/flame/pull/105)
 
 ## 2.0.0-rc.5 - 2020-06-19
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -11,7 +11,8 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ### Fixed
 
-- Leverage `forceUpdate` to re-compute popper positioning in components that have popper still visible.
+- Leverage `update` hook to re-compute popper positioning in components that have popper still visible.
+- In `useOnClickOutside`, use a ref for handler callback to avoid destroying the event listener too early.
 
 ## 2.0.0-rc.5 - 2020-06-19
 
@@ -63,9 +64,10 @@ Additionally, should you leverage the `useOnClickOutside` hook in conjunction wi
 import { usePopper, useOnClickOutside } from '@lightspeed/flame/hooks';
 
 const Example = () => {
-  const clickOutsideRef = React.createRef(null);
   const [targetRef, setTargetRef] = React.useState(null);
   const [popperRef, setPopperRef] = React.useState(null);
+  const clickOutsideRef = React.useRef();
+  clickOutsideRef.current = popperRef;
   const { styles } = usePopper(targetRef, popperRef);
 
   useOnClickOutside(clickOutsideRef, () => console.log('clicked outside!'));
@@ -73,13 +75,7 @@ const Example = () => {
   return (
     <div>
       <div ref={setTargetRef}>target</div>
-      <div
-        ref={ref => {
-          setPopperRef(ref);
-          clickOutsideRef.current = ref;
-        }}
-        style={styles.popper}
-      >
+      <div ref={setPopperRef} style={styles.popper}>
         popper content
       </div>
     </div>

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+### [Unreleased]
+
+### Fixed
+
+- Leverage `forceUpdate` to re-compute popper positioning in components that have popper still visible.
+
 ## 2.0.0-rc.5 - 2020-06-19
 
 ### Breaking

--- a/packages/flame/src/Dropdown/Dropdown.tsx
+++ b/packages/flame/src/Dropdown/Dropdown.tsx
@@ -117,9 +117,10 @@ export const Dropdown: React.FC<Props> = ({
 }) => {
   const [targetRef, setTargetRef] = React.useState(null);
   const [popperRef, setPopperRef] = React.useState(null);
-  const popperComponentRef = React.createRef();
+  const clickOutsideRef = React.useRef();
+  clickOutsideRef.current = popperRef;
 
-  const { styles, forceUpdate } = usePopper(targetRef, popperRef, {
+  const { styles, update } = usePopper(targetRef, popperRef, {
     placement: (placementWhitelist[placement] as any) || placement || 'bottom-start',
     modifiers: [
       {
@@ -145,8 +146,8 @@ export const Dropdown: React.FC<Props> = ({
     }
   });
 
-  useOnClickOutside(popperComponentRef, () => {
-    forceUpdate && forceUpdate();
+  useOnClickOutside(clickOutsideRef, () => {
+    isActive && update && update();
     isActive && setInactive();
   });
 
@@ -176,11 +177,7 @@ export const Dropdown: React.FC<Props> = ({
       </Box>
 
       <DropdownContainer
-        ref={ref => {
-          setPopperRef(ref);
-          // @ts-ignore
-          popperComponentRef.current = ref;
-        }}
+        ref={setPopperRef}
         light
         zIndex={zIndex}
         isActive={isActive}

--- a/packages/flame/src/Dropdown/Dropdown.tsx
+++ b/packages/flame/src/Dropdown/Dropdown.tsx
@@ -119,7 +119,7 @@ export const Dropdown: React.FC<Props> = ({
   const [popperRef, setPopperRef] = React.useState(null);
   const popperComponentRef = React.createRef();
 
-  const { styles } = usePopper(targetRef, popperRef, {
+  const { styles, forceUpdate } = usePopper(targetRef, popperRef, {
     placement: (placementWhitelist[placement] as any) || placement || 'bottom-start',
     modifiers: [
       {
@@ -146,6 +146,7 @@ export const Dropdown: React.FC<Props> = ({
   });
 
   useOnClickOutside(popperComponentRef, () => {
+    forceUpdate && forceUpdate();
     isActive && setInactive();
   });
 

--- a/packages/flame/src/Popover/Popover.tsx
+++ b/packages/flame/src/Popover/Popover.tsx
@@ -68,7 +68,7 @@ export const Popover: React.FC<PopoverProps> = ({
 
   const { isActive, setInactive, setActive } = useToggle(isOpen);
 
-  const { styles, attributes } = usePopper(targetRef, popperRef, {
+  const { styles, attributes, forceUpdate } = usePopper(targetRef, popperRef, {
     placement: placement || 'bottom-start',
     strategy: positionFixed ? 'fixed' : 'absolute',
     modifiers: [
@@ -81,6 +81,7 @@ export const Popover: React.FC<PopoverProps> = ({
 
   useOnClickOutside(clickOutsideRef, () => {
     isActive && autoClose && onClose();
+    forceUpdate && forceUpdate();
   });
 
   useEventListener<KeyboardEvent>('keyup', event => {

--- a/packages/flame/src/Popover/Popover.tsx
+++ b/packages/flame/src/Popover/Popover.tsx
@@ -63,12 +63,13 @@ export const Popover: React.FC<PopoverProps> = ({
 }) => {
   const [targetRef, setTargetRef] = React.useState(null);
   const [popperRef, setPopperRef] = React.useState(null);
-  const clickOutsideRef = React.createRef();
+  const clickOutsideRef = React.useRef();
+  clickOutsideRef.current = popperRef;
   const isFirstPass = React.useRef(true);
 
   const { isActive, setInactive, setActive } = useToggle(isOpen);
 
-  const { styles, attributes, forceUpdate } = usePopper(targetRef, popperRef, {
+  const { styles, attributes, update } = usePopper(targetRef, popperRef, {
     placement: placement || 'bottom-start',
     strategy: positionFixed ? 'fixed' : 'absolute',
     modifiers: [
@@ -81,7 +82,7 @@ export const Popover: React.FC<PopoverProps> = ({
 
   useOnClickOutside(clickOutsideRef, () => {
     isActive && autoClose && onClose();
-    forceUpdate && forceUpdate();
+    isActive && update && update();
   });
 
   useEventListener<KeyboardEvent>('keyup', event => {
@@ -123,11 +124,7 @@ export const Popover: React.FC<PopoverProps> = ({
       {isActive && (
         <PopoverContainer
           light={light}
-          ref={ref => {
-            setPopperRef(ref);
-            // @ts-ignore
-            clickOutsideRef.current = ref; // eslint-disable-line
-          }}
+          ref={setPopperRef}
           className={className}
           zIndex={zIndex as any}
           isActive={isActive}

--- a/packages/flame/src/Tooltip/Tooltip.tsx
+++ b/packages/flame/src/Tooltip/Tooltip.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import { position } from 'styled-system';
 import { themeGet } from '@styled-system/theme-get';
 import { Placement as TooltipPlacement } from '@popperjs/core';
-import { usePopper, useToggle } from '../hooks';
+import { usePopper, useToggle, useOnClickOutside } from '../hooks';
 
 const tooltipOffset = 'space.1';
 const tooltipArrowSize = '5px';
@@ -237,21 +237,31 @@ export const Tooltip: React.FC<TooltipProps> = ({
   const { isActive, setActive, setInactive } = useToggle(active);
   const [referenceElement, setReferenceElement] = React.useState(null);
   const [popperElement, setPopperElement] = React.useState(null);
+  const clickOutsideRef = React.useRef();
+  clickOutsideRef.current = popperElement;
 
-  const { attributes, styles } = usePopper(referenceElement, popperElement, {
+  const { attributes, styles, update } = usePopper(referenceElement, popperElement, {
     placement,
   });
 
+  useOnClickOutside(clickOutsideRef, () => {
+    isActive && update && update();
+  });
+
   const onFocus = () => {
+    isActive && update && update();
     !active && setActive();
   };
   const onBlur = () => {
+    isActive && update && update();
     !active && setInactive();
   };
   const onMouseEnter = () => {
+    isActive && update && update();
     !active && setActive();
   };
   const onMouseLeave = () => {
+    isActive && update && update();
     !active && setInactive();
   };
 
@@ -268,6 +278,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
       </span>
       {isActive && (
         <TooltipContainer
+          ref={setPopperElement}
           as={as || tag || 'div'}
           className={className}
           style={styles.popper}
@@ -275,7 +286,6 @@ export const Tooltip: React.FC<TooltipProps> = ({
             attributes && attributes.popper && attributes.popper['data-popper-placement']
           }
           light={light}
-          ref={setPopperElement}
           zIndex={zIndex}
         >
           {content}

--- a/packages/flame/src/hooks/useOnClickOutside.ts
+++ b/packages/flame/src/hooks/useOnClickOutside.ts
@@ -1,13 +1,19 @@
 import * as React from 'react';
 
 export function useOnClickOutside(ref: any, handler: (event: Event) => void) {
+  const savedCallback = React.useRef(handler);
+
+  React.useEffect(() => {
+    savedCallback.current = handler;
+  }, [handler]);
+
   React.useEffect(() => {
     const listener = (event: Event) => {
       // Do nothing if clicking ref's element or descendent elements
       if (!ref.current || ref.current.contains(event.target)) {
         return;
       }
-      handler(event);
+      savedCallback.current(event);
     };
 
     document.addEventListener('click', listener);
@@ -17,5 +23,5 @@ export function useOnClickOutside(ref: any, handler: (event: Event) => void) {
       document.removeEventListener('click', listener);
       document.removeEventListener('touchstart', listener);
     };
-  }, [ref, handler]);
+  }, [ref]);
 }


### PR DESCRIPTION
## Description

Made it so that active poppers are updated whenever an outside event is triggered (AKA, update when clicked outside and when its active).

I've also updated the useOnClickOutside to not prematurely destroy event listeners. We do this by saving the handler callback as a ref and then using that one inside the effect function.

<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->
Closes #103 

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [x] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [x] I have added tests that prove my fix is effective or that my feature works
