### PR TITLE
Add next/Badge component

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
   command = "yarn build:storybook"
-  publish = "storybook-static"
+  publish = "packages/flame/storybook-static"
   environment = { YARN_VERSION = "1.17.3" }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dev": "yarn && concurrently --kill-others 'yarn dev:tokens' 'yarn dev:themes' 'lerna exec --scope \"@lightspeed/flame\" yarn storybook'",
     "dev:themes": "chokidar './packages/flame/themes/**/*.ts' -c 'lerna run --scope @lightspeed/flame build:themes'",
     "dev:tokens": "chokidar './packages/flame-tokens/src/*.ts' -c 'lerna run --scope @lightspeed/flame-tokens prepublish'",
-    "build:storybook": "yarn bootstrap && build-storybook -c .storybook",
+    "build:storybook": "yarn bootstrap && lerna exec --scope \"@lightspeed/flame\" yarn build-storybook",
     "lerna:version": "lerna version --no-push",
     "lerna:version:revert": "./scripts/revert-lerna-version",
     "version": "node ./scripts/prepare-release",

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -11,8 +11,8 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ### Added
 
-- Introducing the concept of the "next" folder. Whenever we are about to introduce breaking changes to existing components, we will introduce the future component into the corresponding folder. Please note that components within this folder are usually experimental and are subject to changes that might not be documented.([#106](https://github.com/lightspeed/flame/pull/106)
-- Add next/Badge. Should you wish to already leverage and test out the newer Badge component, simply `import { Badge } from '@lightspeed/flame/Badge/next';`([#106](https://github.com/lightspeed/flame/pull/106)
+- Introducing the concept of the "next" folder. Whenever we are about to introduce breaking changes to existing components, we will introduce the future component into the corresponding folder. Please note that components within this folder are usually experimental and are subject to changes that might not be documented ([#106](https://github.com/lightspeed/flame/pull/106)
+- Add next/Badge. Should you wish to already leverage and test out the newer Badge component, simply `import { Badge } from '@lightspeed/flame/Badge/next';` ([#106](https://github.com/lightspeed/flame/pull/106)
 
 ## 2.0.0-rc.6 - 2020-06-19
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Added
+
+- Introducing the concept of the "next" folder. Whenever we are about to introduce breaking changes to existing components, we will introduce the future component into the corresponding folder. Please note that components within this folder are usually experimental and are subject to changes that might not be documented.
+- Add next/Badge. Should you wish to already leverage and test out the newer Badge component, simply `import { Badge } from '@lightspeed/flame/Badge/next';`
+
 ## 2.0.0-rc.5 - 2020-06-19
 
 ### Breaking

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -11,8 +11,8 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ### Added
 
-- Introducing the concept of the "next" folder. Whenever we are about to introduce breaking changes to existing components, we will introduce the future component into the corresponding folder. Please note that components within this folder are usually experimental and are subject to changes that might not be documented.
-- Add next/Badge. Should you wish to already leverage and test out the newer Badge component, simply `import { Badge } from '@lightspeed/flame/Badge/next';`
+- Introducing the concept of the "next" folder. Whenever we are about to introduce breaking changes to existing components, we will introduce the future component into the corresponding folder. Please note that components within this folder are usually experimental and are subject to changes that might not be documented.([#106](https://github.com/lightspeed/flame/pull/106)
+- Add next/Badge. Should you wish to already leverage and test out the newer Badge component, simply `import { Badge } from '@lightspeed/flame/Badge/next';`([#106](https://github.com/lightspeed/flame/pull/106)
 
 ## 2.0.0-rc.5 - 2020-06-19
 

--- a/packages/flame/src/Badge/next/Badge.tsx
+++ b/packages/flame/src/Badge/next/Badge.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { css } from '@styled-system/css';
+
+interface Props extends React.ComponentPropsWithRef<'span'> {
+  /**
+   * Adjust the overall look and feel of a badge.
+   */
+  type?: 'default' | 'danger' | 'primary' | 'success' | 'warning';
+}
+/**
+ * A badge communicates the status of an item or event when placed beside it.
+ * It uses bold colors to quickly signal the intent of an item or event.
+ */
+const Badge: React.FC<Props> = ({ type = 'default', ...restProps }) => (
+  <span
+    className="fl-badge"
+    css={css({
+      display: 'inline-flex',
+      color: 'textHeading',
+      px: 3,
+      lineHeight: 4,
+      border: '1px solid',
+      borderRadius: '12px',
+      fontSize: 'text-s',
+      fontWeight: 'bold',
+      textAlign: 'center',
+      variant: `nextBadgeVariants.${type}`,
+    })}
+    {...restProps}
+  />
+);
+
+export { Badge };

--- a/packages/flame/src/Badge/next/Badge.tsx
+++ b/packages/flame/src/Badge/next/Badge.tsx
@@ -5,13 +5,13 @@ interface Props extends React.ComponentPropsWithRef<'span'> {
   /**
    * Adjust the overall look and feel of a badge.
    */
-  type?: 'default' | 'danger' | 'primary' | 'success' | 'warning';
+  variant?: 'default' | 'danger' | 'primary' | 'success' | 'warning';
 }
 /**
  * A badge communicates the status of an item or event when placed beside it.
  * It uses bold colors to quickly signal the intent of an item or event.
  */
-const Badge: React.FC<Props> = ({ type = 'default', ...restProps }) => (
+const Badge: React.FC<Props> = ({ variant = 'default', ...restProps }) => (
   <span
     className="fl-badge"
     css={css({
@@ -24,7 +24,7 @@ const Badge: React.FC<Props> = ({ type = 'default', ...restProps }) => (
       fontSize: 'text-s',
       fontWeight: 'bold',
       textAlign: 'center',
-      variant: `nextBadgeVariants.${type}`,
+      variant: `nextBadgeVariants.${variant}`,
     })}
     {...restProps}
   />

--- a/packages/flame/src/Badge/next/Badge.tsx
+++ b/packages/flame/src/Badge/next/Badge.tsx
@@ -17,7 +17,7 @@ const Badge: React.FC<Props> = ({ variant = 'default', ...restProps }) => (
     css={css({
       display: 'inline-flex',
       color: 'textHeading',
-      px: 3,
+      px: 2,
       lineHeight: 4,
       border: '1px solid',
       borderRadius: '12px',

--- a/packages/flame/src/Badge/next/index.tsx
+++ b/packages/flame/src/Badge/next/index.tsx
@@ -1,0 +1,3 @@
+import { Badge } from './Badge';
+
+export { Badge };

--- a/packages/flame/src/Badge/story.tsx
+++ b/packages/flame/src/Badge/story.tsx
@@ -3,11 +3,14 @@ import { storiesOf } from '@storybook/react';
 import { withReadme } from 'storybook-readme';
 
 import { Badge, PillBadge, BadgeTypes } from './Badge';
+import { Badge as NextBadge } from './next';
+
 import Readme from './README.md';
 
 const stories = storiesOf('Components|Badge', module).addDecorator(withReadme(Readme));
 
 const statuses: BadgeTypes[] = ['success', 'danger', 'info', 'important', 'warning', 'default'];
+const nextStatuses = ['danger', 'default', 'primary', 'success', 'warning'] as const;
 
 stories.add('Styles', () => (
   <div>
@@ -54,3 +57,19 @@ stories.add('Styles', () => (
     </div>
   </div>
 ));
+
+stories.add(
+  'Next Styles',
+  () => (
+    <div>
+      <div className="sibling-spacing">
+        {nextStatuses.map(status => (
+          <NextBadge key={status} type={status}>
+            {`${status[0].toUpperCase()}${status.slice(1)}`}
+          </NextBadge>
+        ))}
+      </div>
+    </div>
+  ),
+  { percy: { skip: true } },
+);

--- a/packages/flame/src/Badge/story.tsx
+++ b/packages/flame/src/Badge/story.tsx
@@ -58,18 +58,14 @@ stories.add('Styles', () => (
   </div>
 ));
 
-stories.add(
-  'next/Styles',
-  () => (
-    <div>
-      <div className="sibling-spacing">
-        {nextStatuses.map(status => (
-          <NextBadge key={status} type={status}>
-            {`${status[0].toUpperCase()}${status.slice(1)}`}
-          </NextBadge>
-        ))}
-      </div>
+stories.add('next/Styles', () => (
+  <div>
+    <div className="sibling-spacing">
+      {nextStatuses.map(status => (
+        <NextBadge key={status} type={status}>
+          {`${status[0].toUpperCase()}${status.slice(1)}`}
+        </NextBadge>
+      ))}
     </div>
-  ),
-  { percy: { skip: true } },
-);
+  </div>
+));

--- a/packages/flame/src/Badge/story.tsx
+++ b/packages/flame/src/Badge/story.tsx
@@ -62,7 +62,7 @@ stories.add('next/Styles', () => (
   <div>
     <div className="sibling-spacing">
       {nextStatuses.map(status => (
-        <NextBadge key={status} type={status}>
+        <NextBadge key={status} variant={status}>
           {`${status[0].toUpperCase()}${status.slice(1)}`}
         </NextBadge>
       ))}

--- a/packages/flame/src/Badge/story.tsx
+++ b/packages/flame/src/Badge/story.tsx
@@ -59,7 +59,7 @@ stories.add('Styles', () => (
 ));
 
 stories.add(
-  'Next Styles',
+  'next/Styles',
   () => (
     <div>
       <div className="sibling-spacing">

--- a/packages/flame/themes/dark/components/badge.ts
+++ b/packages/flame/themes/dark/components/badge.ts
@@ -27,4 +27,27 @@ const badgeVariants: BadgeVariants = {
   },
 };
 
-export { badgeVariants };
+const nextBadgeVariants = {
+  danger: {
+    bg: 'maple-200',
+    borderColor: 'maple-300',
+  },
+  default: {
+    bg: 'gray-100',
+    borderColor: 'gray-200',
+  },
+  primary: {
+    bg: 'blue-100',
+    borderColor: 'blue-200',
+  },
+  success: {
+    bg: 'green-200',
+    borderColor: 'green-400',
+  },
+  warning: {
+    bg: 'orange-200',
+    borderColor: 'orange-300',
+  },
+};
+
+export { badgeVariants, nextBadgeVariants };

--- a/packages/flame/themes/dark/index.ts
+++ b/packages/flame/themes/dark/index.ts
@@ -2,7 +2,7 @@ import { lightspeedTheme } from '@lightspeed/flame-tokens';
 
 import { colors } from './colors';
 import { alertVariants } from './components/alert';
-import { badgeVariants } from './components/badge';
+import { badgeVariants, nextBadgeVariants } from './components/badge';
 import { buttonVariants, buttonIconVariants } from './components/button';
 import { cardStyles, cardVariants } from './components/card';
 import { checkboxStyles } from './components/checkbox';
@@ -34,6 +34,7 @@ const theme: FlameUI = {
   ...themeUI,
   alertVariants,
   badgeVariants,
+  nextBadgeVariants,
   buttonVariants,
   buttonIconVariants,
   cardStyles,

--- a/packages/flame/themes/flame/components/badge.ts
+++ b/packages/flame/themes/flame/components/badge.ts
@@ -27,4 +27,27 @@ const badgeVariants: BadgeVariants = {
   },
 };
 
-export { badgeVariants };
+const nextBadgeVariants = {
+  danger: {
+    bg: 'maple-200',
+    borderColor: 'maple-300',
+  },
+  default: {
+    bg: 'gray-100',
+    borderColor: 'gray-200',
+  },
+  primary: {
+    bg: 'blue-100',
+    borderColor: 'blue-200',
+  },
+  success: {
+    bg: 'green-200',
+    borderColor: 'green-400',
+  },
+  warning: {
+    bg: 'orange-200',
+    borderColor: 'orange-300',
+  },
+};
+
+export { badgeVariants, nextBadgeVariants };

--- a/packages/flame/themes/flame/index.ts
+++ b/packages/flame/themes/flame/index.ts
@@ -3,7 +3,7 @@ import { lightspeedTheme } from '@lightspeed/flame-tokens';
 import { colors } from './colors';
 
 import { alertVariants, alertInCardVariants } from './components/alert';
-import { badgeVariants } from './components/badge';
+import { badgeVariants, nextBadgeVariants } from './components/badge';
 import { buttonVariants, buttonIconVariants } from './components/button';
 import { cardStyles, cardVariants } from './components/card';
 import { checkboxStyles } from './components/checkbox';
@@ -37,6 +37,7 @@ const theme: FlameUI = {
   alertVariants,
   alertInCardVariants,
   badgeVariants,
+  nextBadgeVariants,
   buttonVariants,
   buttonIconVariants,
   cardStyles,

--- a/packages/flame/themes/oldskool/components/badge.ts
+++ b/packages/flame/themes/oldskool/components/badge.ts
@@ -30,23 +30,23 @@ const badgeVariants: BadgeVariants = {
 const nextBadgeVariants = {
   danger: {
     bg: 'maple-100',
-    borderColor: 'maple-300',
+    borderColor: 'maple',
   },
   default: {
     bg: 'gray-100',
-    borderColor: 'gray-300',
+    borderColor: 'gray',
   },
   primary: {
     bg: 'blue-100',
-    borderColor: 'blue-300',
+    borderColor: 'blue',
   },
   success: {
     bg: 'green-100',
-    borderColor: 'green-300',
+    borderColor: 'green',
   },
   warning: {
     bg: 'orange-100',
-    borderColor: 'orange-300',
+    borderColor: 'orange',
   },
 };
 

--- a/packages/flame/themes/oldskool/components/badge.ts
+++ b/packages/flame/themes/oldskool/components/badge.ts
@@ -27,4 +27,27 @@ const badgeVariants: BadgeVariants = {
   },
 };
 
-export { badgeVariants };
+const nextBadgeVariants = {
+  danger: {
+    bg: 'maple-100',
+    borderColor: 'maple-300',
+  },
+  default: {
+    bg: 'gray-100',
+    borderColor: 'gray-300',
+  },
+  primary: {
+    bg: 'blue-100',
+    borderColor: 'blue-300',
+  },
+  success: {
+    bg: 'green-100',
+    borderColor: 'green-300',
+  },
+  warning: {
+    bg: 'orange-100',
+    borderColor: 'orange-300',
+  },
+};
+
+export { badgeVariants, nextBadgeVariants };

--- a/packages/flame/themes/oldskool/index.ts
+++ b/packages/flame/themes/oldskool/index.ts
@@ -2,7 +2,7 @@ import { oldSkoolTheme } from '@lightspeed/flame-tokens';
 
 import { colors } from './colors';
 import { alertVariants, alertInCardVariants } from './components/alert';
-import { badgeVariants } from './components/badge';
+import { badgeVariants, nextBadgeVariants } from './components/badge';
 import { buttonVariants, buttonIconVariants } from './components/button';
 import { cardStyles, cardVariants } from './components/card';
 import { checkboxStyles } from './components/checkbox';
@@ -36,6 +36,7 @@ const theme: FlameUI = {
   alertVariants,
   alertInCardVariants,
   badgeVariants,
+  nextBadgeVariants,
   buttonVariants,
   buttonIconVariants,
   cardStyles,

--- a/packages/flame/typings/flame/index.d.ts
+++ b/packages/flame/typings/flame/index.d.ts
@@ -654,6 +654,7 @@ declare interface FlameUI {
   alertVariants: AlertVariants;
   alertInCardVariants?: any;
   badgeVariants: BadgeVariants;
+  nextBadgeVariants: any;
   buttonVariants: ButtonVariants;
   buttonIconVariants: ButtonIconVariants;
   cardStyles: CardStyles;


### PR DESCRIPTION
## Description

Badge is yet another one of those components that require an overhaul.

I'm introducing the concept of the "next" folder. Whenever we are about to introduce breaking changes to existing components, we will introduce the future component into the corresponding "next" folder. Please note that components within this folder are usually experimental and are subject to changes that might not be documented.

For the most part, they `should` be feature complete, so you shouldn't have the rug pulled from underneath too often. Since we want to lock release cycles on a more regular basis (something like 3 month cycle), this'll make progressive migration a bit easier.

The instant we change to a different major version, the `next/${component}` will be wiped clean, as that component will replace whatever existing component it is meant to replace.

We'll be adding the "next/Badge" component so that you may test your hand out with the new component and progressively migrate towards it.


<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->
<!-- Closes #XXX -->

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [x] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [x] I have added tests that prove my fix is effective or that my feature works
