### PR TITLE
Set higher zIndex for ToasterContainer

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -11,7 +11,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ### Fixed
 
-- Adjust z-index of PopoverContainer to go above the Modal overlay
+- Adjust z-index of PopoverContainer to go above the Modal overlay ([#107](https://github.com/lightspeed/flame/pull/107)
 
 ## 2.0.0-rc.5 - 2020-06-19
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Fixed
+
+- Adjust z-index of PopoverContainer to go above the Modal overlay
+
 ## 2.0.0-rc.5 - 2020-06-19
 
 ### Breaking

--- a/packages/flame/src/Toaster/Toaster.tsx
+++ b/packages/flame/src/Toaster/Toaster.tsx
@@ -178,7 +178,9 @@ const ToasterContainer: React.FC = ({ children }) => (
       overflowX: 'hidden',
       overflowY: 'auto',
       position: 'fixed',
-      zIndex: 1000,
+      // @TODO: z-index values NEED to be in the theme
+      // Or else we end up with fun scenarios like these.
+      zIndex: 10001,
       bottom: 0,
       flexDirection: 'column',
       pointerEvents: 'none',

--- a/packages/flame/src/Toaster/story.tsx
+++ b/packages/flame/src/Toaster/story.tsx
@@ -6,6 +6,7 @@ import { ToasterProvider, useToasts } from './index';
 import { ActionableToastContent, Toaster } from './Toaster';
 import { Button } from '../Button';
 import { Heading2 } from '../Text';
+import { Modal } from '../Modal';
 
 const stories = storiesOf('Components|Toaster', module).addDecorator(withReadme(Readme));
 
@@ -177,3 +178,28 @@ stories.add('percy snapshots', () => {
     </ToasterProvider>
   );
 });
+
+stories.add(
+  'Toaster in a modal',
+  () => (
+    <ToasterProvider>
+      <Modal isOpen={true}>
+        <div css={{ padding: '8px' }}>
+          <div>
+            <Heading2>A toast will auto dismiss itself</Heading2>
+            <AutoDismissToastExample />
+          </div>
+          <div>
+            <Heading2>A toast with an action will have a progress bar</Heading2>
+            <ActionableToastExample />
+          </div>
+          <div>
+            <Heading2>Create a toast with a long message</Heading2>
+            <LongToastExample />
+          </div>
+        </div>
+      </Modal>
+    </ToasterProvider>
+  ),
+  { percy: { skip: true } },
+);


### PR DESCRIPTION
## Description

Lower z-index meant the toaster was getting stuck behind the modal overlay.

<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->
<!-- Closes #XXX -->

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [x] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [x] I have added tests that prove my fix is effective or that my feature works
