### PR TITLE
Export typing for next/Badge

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -12,7 +12,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 ### Fixed
 
 - Smoothed out border-radius for next/Badge ([#108](https://github.com/lightspeed/flame/pull/#108)
-- Export next/Badge prop typing and variant types
+- Export next/Badge prop typing and variant types ([#110](https://github.com/lightspeed/flame/pull/#110)
 
 ## 2.0.0-rc.7 - 2020-06-22
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -12,6 +12,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 ### Fixed
 
 - Smoothed out border-radius for next/Badge ([#108](https://github.com/lightspeed/flame/pull/#108)
+- Export next/Badge prop typing and variant types
 
 ## 2.0.0-rc.7 - 2020-06-22
 

--- a/packages/flame/src/Badge/next/Badge.tsx
+++ b/packages/flame/src/Badge/next/Badge.tsx
@@ -1,17 +1,20 @@
 import * as React from 'react';
 import { css } from '@styled-system/css';
 
-interface Props extends React.ComponentPropsWithRef<'span'> {
+export type BadgeVariants = 'default' | 'danger' | 'primary' | 'success' | 'warning';
+export interface BadgeProps extends React.ComponentPropsWithRef<'span'> {
   /**
    * Adjust the overall look and feel of a badge.
+   * Possible variants are:
+   * 'default' | 'danger' | 'primary' | 'success' | 'warning'
    */
-  variant?: 'default' | 'danger' | 'primary' | 'success' | 'warning';
+  variant?: BadgeVariants;
 }
 /**
  * A badge communicates the status of an item or event when placed beside it.
  * It uses bold colors to quickly signal the intent of an item or event.
  */
-const Badge: React.FC<Props> = ({ variant = 'default', ...restProps }) => (
+export const Badge: React.FC<BadgeProps> = ({ variant = 'default', ...restProps }) => (
   <span
     className="fl-badge"
     css={css({
@@ -29,5 +32,3 @@ const Badge: React.FC<Props> = ({ variant = 'default', ...restProps }) => (
     {...restProps}
   />
 );
-
-export { Badge };


### PR DESCRIPTION
## Description

Types were not being exported for badges, which can be annoying when trying to build on-top of this component.

Simply export the types.

<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->
<!-- Closes #XXX -->

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [x] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [x] I have added tests that prove my fix is effective or that my feature works
