### PR TITLE
Use tags as target for publish action. Snapshot label for visual diffing

### DIFF
--- a/.github/workflows/chromatic-label.yml
+++ b/.github/workflows/chromatic-label.yml
@@ -1,17 +1,15 @@
-name: Test
+name: Chromatic on label
+on: [pull_request]
 
-on:
-  push:
-    branches:
-      - '**'
-    tags-ignore:
-      - '**'
 jobs:
-  build:
-    name: Test, lint, typecheck
+  snapshot:
+    name: Run visual regression tests with chromatic (label triggered)
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'snapshot') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Read .nvmrc
         run: echo ::set-output name=nvmrc::$(cat .nvmrc)
         id: nvm
@@ -26,14 +24,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-cache-v1-
       - name: Install
-        run: yarn install --frozen-lockfile
-      - name: Bootstrap
-        run: yarn bootstrap
-      - name: Test
-        run: yarn test:ci
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - name: Lint
-        run: yarn lint
-      - name: Typecheck
-        run: yarn typecheck
+        run: yarn install --frozen-lockfile && yarn bootstrap
+      - uses: chromaui/action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches:
       - master
+  push:
+    branches:
+      - master
 jobs:
   snapshot:
     name: Run visual regression tests with chromatic

--- a/.github/workflows/publish-lerna.yml
+++ b/.github/workflows/publish-lerna.yml
@@ -1,8 +1,8 @@
 on:
   push:
-    branches:
-      - master
-      - next
+    tags:
+      - '@lightspeed*'
+
 name: Publish lerna
 jobs:
   publish:

--- a/.github/workflows/publish-mainline.yml
+++ b/.github/workflows/publish-mainline.yml
@@ -1,8 +1,8 @@
 on:
   push:
-    branches:
-      - master
-      - next
+    tags:
+      - '@lightspeed*'
+
 name: Publish mainline
 jobs:
   publish:


### PR DESCRIPTION
## Description

Publishing scripts were being ran on every commit on master/next.

Technically, we only want to publish on new tag, not on commits.

<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->
<!-- Closes #XXX -->

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [ ] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [ ] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [ ] I have added tests that prove my fix is effective or that my feature works
