### PR TITLE
Loosen typings for themeGet

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -11,7 +11,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ### Fixed
 
-- Loosen typing for `themeGet`
+- Loosen typing for `themeGet` ([#116](https://github.com/lightspeed/flame/pull/116))
 
 ## 1.6.1 - 2020-06-05
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Fixed
+
+- Loosen typing for `themeGet`
+
 ## 1.6.1 - 2020-06-05
 
 ### Fixed

--- a/packages/flame/scripts/build-themes.ts
+++ b/packages/flame/scripts/build-themes.ts
@@ -73,7 +73,7 @@ ${types}
 type ThemePath<T> = T | flameTheme;
 
 function themeGet<T>(path: ThemePath<T>, defaultValue?: string) {
-  return function drill(props: { theme : any }) {
+  return function drill(props: { theme? : any }) {
     return baseThemeGet(path, defaultValue)(props);
   };
 }


### PR DESCRIPTION
## Description

Typings was a bit too aggressive for themeGet. Set the theme as optional.

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [ ] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [ ] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [ ] I have added tests that prove my fix is effective or that my feature works
