### PR TITLE
Remove next dist-tag from publishConfig

### DIFF
--- a/packages/flame/package.json
+++ b/packages/flame/package.json
@@ -65,8 +65,5 @@
     "react-docgen-typescript": "^1.15.1",
     "rimraf": "2.6.2",
     "ts-node": "8.3.0"
-  },
-  "publishConfig": {
-    "tag": "next"
   }
 }


### PR DESCRIPTION
## Description

Releases `master` should always be marked as `latest`. This only applies to the `next` branch.

<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->
<!-- Closes #XXX -->

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [ ] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [ ] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [ ] I have added tests that prove my fix is effective or that my feature works
