### PR TITLE
Upgraded react-popper to 2.2.4

### DIFF
--- a/.github/workflows/chromatic-label.yml
+++ b/.github/workflows/chromatic-label.yml
@@ -14,7 +14,7 @@ jobs:
         run: echo ::set-output name=nvmrc::$(cat .nvmrc)
         id: nvm
       - name: Setup node
-        uses: actions/setup-node@v1.1.1
+        uses: actions/setup-node@v2
         with:
           node-version: '${{ steps.nvm.outputs.nvmrc }}'
       - uses: actions/cache@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         run: echo ::set-output name=nvmrc::$(cat .nvmrc)
         id: nvm
       - name: Setup node
-        uses: actions/setup-node@v1.1.1
+        uses: actions/setup-node@v2
         with:
           node-version: '${{ steps.nvm.outputs.nvmrc }}'
       - uses: actions/cache@v1

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -13,6 +13,10 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 - Typecast Button to bypass weird automatic type generation shenanigans ([#125](https://github.com/lightspeed/flame/pull/125))
 
+### Fixed
+
+- Upgrade react-popper 2.2.4 ([#520](https://github.com/lightspeed/flame/pull/133))
+
 ## 2.0.0 - 2020-07-17
 
 See the full changeset on ([#99](https://github.com/lightspeed/flame/pull/99)).

--- a/packages/flame/package.json
+++ b/packages/flame/package.json
@@ -45,7 +45,7 @@
     "@types/styled-system": "^5.1.9",
     "polished": "^2.3.0",
     "react-modal": "^3.5.1",
-    "react-popper": "^2.2.3",
+    "react-popper": "^2.2.4",
     "react-select": "^2.0.0",
     "react-toast-notifications": "^2.4.0",
     "styled-system": "5.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16433,7 +16433,7 @@ react-popper-tooltip@^2.11.0, react-popper-tooltip@^2.8.3:
     "@babel/runtime" "^7.9.2"
     react-popper "^1.3.7"
 
-react-popper@^1.3.7, react-popper@^2.2.1, react-popper@^2.2.3:
+react-popper@^1.3.7, react-popper@^2.2.1, react-popper@^2.2.4:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.3.tgz#33d425fa6975d4bd54d9acd64897a89d904b9d97"
   integrity sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==


### PR DESCRIPTION
## Description

With the upgrade to React 17, the popover closes imminently after opening. I've found [this issue](https://github.com/popperjs/react-popper/issues/392) in the `react-popper` library. The issue led to the[ 2.2.4 release](https://github.com/popperjs/react-popper/releases/tag/v2.2.4) of `react-popper` which hopefully fixes the auto close issue.

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [x] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [ ] I have added tests that prove my fix is effective or that my feature works
