### PR TITLE
Add tipping icon

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Added
+
+- Tipping Icon ([#136](https://github.com/lightspeed/flame/pull/136))
+
 ## 2.0.1-alpha.2 - 2021-01-28
 
 - Version bump because lerna

--- a/packages/flame/svg/Icons/icon-tipping.svg
+++ b/packages/flame/svg/Icons/icon-tipping.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g id="tipping"><path id="base-1" d="M5 9H4l-3 2 2 4h1l2-1 2 1h1l6-3 1-1-1-1h-5l1 2-1 1-5-1v-1l5 1-1-1-4-2z"/><path id="base-2" d="M11 4a2 2 0 10-1 5 2 2 0 001-5zM6 1a2 2 0 100 4 2 2 0 000-4z" opacity=".7" fill-rule="evenodd" clip-rule="evenodd"/></g></svg>


### PR DESCRIPTION
## Description

Which problem(s) does it solve and how? What does this PR add?

Adds Tipping icon for retail
![image](https://user-images.githubusercontent.com/68552500/110370212-66132300-8019-11eb-8aaa-2cea33edf3ca.png)

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [x] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [ ] I have added tests that prove my fix is effective or that my feature works
