### PR TITLE
Fix clip-rule warning by converting the svg property into a React format of clipRule

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -9,7 +9,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ## [Unreleased]
 
-### Added
+### Fixed
 
 - Fix clip-rule warning by converting the svg property into a React format of clipRule ([#161](https://github.com/lightspeed/flame/pull/161))
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Added
+
+- Fix clip-rule warning by converting the svg property into a React format of clipRule ([#161](https://github.com/lightspeed/flame/pull/161))
+
 ## 2.3.1 - 2022-03-04
 
 ### Added

--- a/packages/flame/scripts/generate-icons.js
+++ b/packages/flame/scripts/generate-icons.js
@@ -89,6 +89,7 @@ export { NextIcon as Icon${componentIconName} };`;
                 .replace(/<\/?svg(?:\s.+?)?>/g, '')
                 .replace(/id="((base|details)-\d)"/g, 'style="fill: var(--cr-icon-$1-fill)"')
                 .replace(/fill-rule=/g, 'fillRule=')
+                .replace(/clip-rule=/g, 'clipRule=')
                 .replace(/<g.*?>/, `<symbol id="cr-icon-${iconName}">`)
                 .replace(/<\/g>(?!.*<\/g>)/, '</symbol>')
                 .trim(),


### PR DESCRIPTION
## Description

When adding the newer icons, there was a svg property that was not accounted for.

<img width="764" alt="image" src="https://user-images.githubusercontent.com/19352322/161329556-81a3b4df-0851-4561-9c97-00d12d9ef73c.png">


## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [ ] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [ ] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [ ] I have added tests that prove my fix is effective or that my feature works
