### PR TITLE
Fix clip-rule warning on Icon Components

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Fixed
+
+- Fix clip-rule warning by converting the svg property into a React format of clipRule for Components ([#162](https://github.com/lightspeed/flame/pull/162))
+
 ## 2.3.2 - 2022-04-04
 
 ### Fixed

--- a/packages/flame/scripts/generate-icons.js
+++ b/packages/flame/scripts/generate-icons.js
@@ -62,6 +62,7 @@ fs.readdir(svgDirPath, (err, svgPaths) => {
                 'className="cr-icon__$2 cr-icon__$1" fill={$2Color || $2Color$3}',
               )
               .replace(/fill-rule=/g, 'fillRule=')
+              .replace(/clip-rule=/g, 'clipRule=')
               .replace(/<\/?g(?:\s.+?)?>/g, '');
 
             const component = `

--- a/packages/flame/scripts/run-svgo.js
+++ b/packages/flame/scripts/run-svgo.js
@@ -65,6 +65,7 @@ const flameIcon = {
       if (item.isElem('g') && item.hasAttr('id')) {
         if (/^symbols/i.test(item.attr('id').value)) {
           item.removeAttr('fill-rule');
+          item.removeAttr('clip-rule');
           item.removeAttr('id');
         }
       }


### PR DESCRIPTION
## Description

The fix in #161  was only for the svg sprite, adding the same change for the generated `<Icon />` components

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [ ] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [ ] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [ ] I have added tests that prove my fix is effective or that my feature works
