### PR TITLE
Add children to Dropdown props interface

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -84,7 +84,7 @@ cd /path/to/your/project
 yarn link "@lightspeed/flame"
 ```
 
-Note that in the above example you need to run `yarn link` inside the `dist` folder of a given package. If you're not seeing local changes reflected in your project, you may need to run `yarn build` inside the `packages/flame` folder and then restart your project's web/typescript server.
+Note that in the above example you need to run `yarn link` inside the `dist` folder of a given package. If you're not seeing local changes reflected in your project, you may need to run `yarn build` inside the `packages/flame` folder and then restart your project's web server or [typescript server](https://tinytip.co/tips/vscode-restart-ts).
 
 #### Run tests
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -72,6 +72,20 @@ yarn dev
 
 This will install/update dependencies, including `packages/` ones, and launch Storybook on [http://localhost:6006/](http://localhost:6006/).
 
+#### Link a local version of @lightspeed/flame to your project
+
+If you want to test your changes in a local project, you can link your local version of `@lightspeed/flame` using [yarn link](https://classic.yarnpkg.com/en/docs/cli/link/), e.g.
+
+```sh
+# Link the react package
+cd packages/flame/dist
+yarn link
+cd /path/to/your/project
+yarn link "@lightspeed/flame"
+```
+
+Note that in the above example you need to run `yarn link` inside the `dist` folder of a given package. If you're not seeing local changes reflected in your project, you may need to run `yarn build` inside the `packages/flame` folder and then restart your project's web/typescript server.
+
 #### Run tests
 
 ```sh

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Added
+
+- Add children to Dropdown props interface ([#171](https://github.com/lightspeed/flame/pull/171))
+
 ## 2.4.2 - 2022-10-12
 
 ### Added

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -12,6 +12,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 ### Added
 
 - Add children to Dropdown props interface ([#171](https://github.com/lightspeed/flame/pull/171))
+- Update CONTRIBUTING.md about using `yarn link` ([#172](https://github.com/lightspeed/flame/pull/171))
 
 ## 2.4.2 - 2022-10-12
 

--- a/packages/flame/src/Dropdown/Dropdown.tsx
+++ b/packages/flame/src/Dropdown/Dropdown.tsx
@@ -18,6 +18,7 @@ type Placement = 'start' | 'center' | 'end' | PopperPlacement;
 
 interface Props extends Merge<PopoverContainerProps, Omit<ButtonProps, 'onClick'>> {
   buttonContent: React.ReactNode;
+  children: React.ReactNode;
   initiallyOpen?: boolean;
   placement?: Placement;
   onClick?: (toggle: () => void, event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;


### PR DESCRIPTION
## Description

Addresses #170 but does not close it. For now we're making this one change in this one component we need as a way to kick the tires on contributing to Flame and to make sure it works as we expect.

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

Ideally you should clone the flame repo locally with this branch and
- `cd` into `/packages/flame/dist`
- run `yarn link`
- `cd` into your React 18 / Typescript project
- run `yarn link "@lightspeed/flame"`
- verify you can use `<Dropdown>` in your app without seeing TS errors about `children` missing in the component props

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [ ] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [ ] I have added tests that prove my fix is effective or that my feature works
