### PR TITLE
Revert: remove children from Dropdown type

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -93,7 +93,7 @@ yarn unlink "@lightspeed/flame" # unlink your local flame
 yarn install --force # reinstall published flame
 ```
 
-You may also have to restart your TS server again as well.
+You may also have to restart your TypeScript server again.
 
 #### Run tests
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -86,6 +86,15 @@ yarn link "@lightspeed/flame"
 
 Note that in the above example you need to run `yarn link` inside the `dist` folder of a given package. If you're not seeing local changes reflected in your project, you may need to run `yarn build` inside the `packages/flame` folder and then restart your project's web server or [typescript server](https://tinytip.co/tips/vscode-restart-ts).
 
+When you are finished, here's how you can unlink the local version of flame from your project:
+
+```sh
+yarn unlink "@lightspeed/flame" # unlink your local flame
+yarn install --force # reinstall published flame
+```
+
+You may also have to restart your TS server again as well.
+
 #### Run tests
 
 ```sh

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,11 +6,13 @@ We use the `next` (canary) branch as our main working branch. All major change s
 
 ## Versioning and publishing the mainline branch
 
-1. Make sure your local `master` branch is up to date including tags
-2. Run `yarn release`
+1. Make sure your local `next` branch is up to date including tags
+2. Run `yarn release` from inside the root of the project
 3. Choose versions for updated packages (including version bumps for packages with dependencies)
-4. Confirm changes, which will automatically update packages, create tags, push to remote `master` and publish packages to npm through [GitHub Actions](https://github.com/lightspeed/flame/tree/master/.github/workflows/)
+4. Confirm changes, which will automatically update packages, create tags, push to remote `next` and publish packages to npm through [GitHub Actions](https://github.com/lightspeed/flame/tree/master/.github/workflows/)
 5. Go to [GitHub releases](https://github.com/lightspeed/flame/releases) and edit the newly created tags. Copy the section of the updated CHANGELOGs in the description (_This is a manual step for now that we'll enventually automate with the [GitHub Releases API](https://developer.github.com/v3/repos/releases/)_)
+
+The newly release will be visible at https://www.npmjs.com/package/@lightspeed/flame under the `next` tag.
 
 **Note:** local manual publishing can still be done with `yarn release-and-publish` in case it's needed.
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Added
+
+- Enable any children type inside Dropdown ([#172](https://github.com/lightspeed/flame/pull/172))
+
 ## 2.4.3 - 2022-10-13
 
 ### Added

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -12,13 +12,15 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 ### Added
 
 - Enable any children type inside Dropdown ([#172](https://github.com/lightspeed/flame/pull/172))
+- Add more `yarn link` notes to docs ([#172](https://github.com/lightspeed/flame/pull/172))
+- Update release docs about using `next` branch ([#172](https://github.com/lightspeed/flame/pull/172))
 
 ## 2.4.3 - 2022-10-13
 
 ### Added
 
 - Add children to Dropdown props interface ([#171](https://github.com/lightspeed/flame/pull/171))
-- Update CONTRIBUTING.md about using `yarn link` ([#172](https://github.com/lightspeed/flame/pull/171))
+- Update CONTRIBUTING.md about using `yarn link` ([#171](https://github.com/lightspeed/flame/pull/171))
 
 ## 2.4.2 - 2022-10-12
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -11,7 +11,7 @@ Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/maste
 
 ### Added
 
-- Enable any children type inside Dropdown ([#172](https://github.com/lightspeed/flame/pull/172))
+- Revert 2.4.3: remove children from Dropdown type ([#172](https://github.com/lightspeed/flame/pull/172))
 - Add more `yarn link` notes to docs ([#172](https://github.com/lightspeed/flame/pull/172))
 - Update release docs about using `next` branch ([#172](https://github.com/lightspeed/flame/pull/172))
 

--- a/packages/flame/src/Dropdown/Dropdown.tsx
+++ b/packages/flame/src/Dropdown/Dropdown.tsx
@@ -18,7 +18,6 @@ type Placement = 'start' | 'center' | 'end' | PopperPlacement;
 
 interface Props extends Merge<PopoverContainerProps, Omit<ButtonProps, 'onClick'>> {
   buttonContent: React.ReactNode;
-  children: React.ReactNode;
   initiallyOpen?: boolean;
   placement?: Placement;
   onClick?: (toggle: () => void, event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;


### PR DESCRIPTION
## Description

Revert the primary change in #171, re: the `Dropdown` props interface. 

The new typing of `React.node` is too strict, despite what the storybook docs suggest. The Dropdown can accept other children types, like a child function that contains the close event as first parameter, as seen in this first example: https://lightspeed-flame.netlify.app/?path=/story/components-dropdown--story.

Instead of trying to find a better more flexible and specific type, remove it for now and revisit later. We can look at this in context of upgrading the entire package for React 18 compatibility. FWIW the [lighthouse-insights app](https://github.com/lightspeed-hospitality/lighthouse-insights) will likely downgrade to React 17 instead to ensure compatibility with Flame.

## How to test?

Same as in #171. Flame should work exactly as before that PR, but the docs will remain updated.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [ ] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [ ] I have added tests that prove my fix is effective or that my feature works
