### PR TITLE
Add React 17 to peer deps

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Refer to the [CONTRIBUTING guide](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) for more info.
 
+## [Unreleased]
+
+### Dependencies
+
+- Add React 17 to peer deps ([#174](https://github.com/lightspeed/flame/pull/174))
+
 ## 2.4.4 - 2022-10-14
 
 ### Added

--- a/packages/flame/package.json
+++ b/packages/flame/package.json
@@ -34,8 +34,8 @@
     "@emotion/core": "^10.0.0",
     "@emotion/styled": "^10.0.0",
     "emotion-theming": "^10.0.0",
-    "react": "^16.8.0-0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0-0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "dependencies": {
     "@popperjs/core": "^2.4.2",


### PR DESCRIPTION
## Description

Should be fine, but make sure you test if you do use React 17 https://reactjs.org/blog/2020/08/10/react-v17-rc.html#other-breaking-changes 🙂 

<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->
<!-- Closes #XXX -->

## How to test?

- Checkout branch, run `yarn dev`
- Open [Storybook](http://localhost:6006)
- Or check the deploy preview on Netlify (link available in comments)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md) guide
- [x] I have prepared [CHANGELOGs](https://github.com/lightspeed/flame/blob/master/.github/CONTRIBUTING.md#git-workflow) for release
- [ ] I have tested my changes on [supported browsers](https://browserl.ist/?q=%3E0.25%25%2C+not+op_mini+all%2C+not+ie+%3C%3D+11)
- [ ] I have added tests that prove my fix is effective or that my feature works
